### PR TITLE
Stripe Connect launch: payments, fees, onboarding, and a pile of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ next-env.d.ts
 # Supabase credentials (local dev)
 .supabase-pat
 .supabase-project-key
+.vercel-token


### PR DESCRIPTION
## Summary

27 commits covering the Stripe Connect launch and everything built during pre-launch testing.

### Payments
- **Stripe Connect Express onboarding**: pool creators connect their bank account once; all later pools inherit it automatically
- **10% platform fee** via `application_fee_amount` — creators keep 90% of every guess (verified end-to-end with real test charges)
- **Price limits**: $10 min guess floor, $200 ceiling max; defaults raised to $15/$60 based on real pool data (median guess was $45.86)
- Webhook refactored to write guesses via SECURITY DEFINER RPCs with the anon key — `SUPABASE_SERVICE_ROLE_KEY` no longer needed
- Place Guess button disabled until the pool owner finishes Stripe onboarding (no more submit-then-error)
- `/admin/fees` page: platform earnings dashboard (gated by `ADMIN_EMAILS` env var)

### Forms & UX
- Image uploads: drag-and-drop now actually saves (dropped files injected into the file input); processing state + save button disabled mid-read
- Create Pool button disabled until all required fields valid (incl. slug availability)
- Client-side video URL validation using the same helper as the server
- Drag-over highlight on all drop zones
- Shared DatePicker on close pool page
- Empty states for My Babies (crying baby SVG + CTA) and My Guesses (thin baby SVG)
- FAQ section on homepage (fees, payouts, settings, recommendations — figures driven from lib/constants)

### Auth & infra
- Fix stale navbar after login (full reload instead of client-side push)
- Dev server consolidated on port 8000; Supabase auth URLs + site_url updated via Management API

### Tests
- 42 unit tests (pricing curve, rankings, slugs, video embeds, dates) + smoke-test script + testing guide docs

## Post-merge deploy steps
- [x] Vercel: NEXT_PUBLIC_BASE_URL=https://www.bellcurve.baby (fixed — was Supabase URL!)
- [x] Vercel: ADMIN_EMAILS set
- [x] Stripe live webhook: account.updated added
- [ ] Real-card smoke test, then refund