### PR TITLE
Refund handling: webhook sync + totals fix

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -260,6 +260,34 @@ export async function POST(req: NextRequest) {
         console.log(`Marked pool(s) with account ${account.id} as onboarding complete`);
       }
     }
+  } else if (event.type === "charge.refunded") {
+    // Refund processed (in the Stripe dashboard or via API): mark the guess
+    // as refunded so it no longer counts in totals/rankings. The row stays
+    // for audit history.
+    const charge = event.data.object as Stripe.Charge;
+    const paymentIntentId =
+      typeof charge.payment_intent === "string"
+        ? charge.payment_intent
+        : charge.payment_intent?.id;
+
+    if (!paymentIntentId) {
+      console.error("charge.refunded without payment_intent:", charge.id);
+    } else {
+      const supabase = getAnonClient();
+      const { error } = await supabase.rpc("mark_guess_refunded", {
+        p_payment_id: paymentIntentId,
+      });
+      if (error) {
+        // Not finding a guess just means the charge wasn't one of ours
+        // (e.g. a test charge) — log but still 200 so Stripe doesn't retry.
+        console.warn(
+          `Could not mark guess refunded for ${paymentIntentId}:`,
+          error.message
+        );
+      } else {
+        console.log(`Marked guess refunded for payment ${paymentIntentId}`);
+      }
+    }
   } else {
     console.log(`Received unhandled event type: ${event.type}`);
   }

--- a/components/ui/baby/BabyPoolClient.tsx
+++ b/components/ui/baby/BabyPoolClient.tsx
@@ -205,10 +205,9 @@ export function BabyPoolClient({
   });
 
   // Calculate total donations from all guesses
-  const totalDonations = guesses.reduce(
-    (sum, guess) => sum + (guess.calculated_price || 0),
-    0
-  );
+  const totalDonations = guesses
+    .filter((guess) => guess.payment_status !== "refunded")
+    .reduce((sum, guess) => sum + (guess.calculated_price || 0), 0);
 
   const stripeConnected = Boolean(
     pool.stripe_account_id && pool.stripe_onboarding_complete

--- a/database.types.ts
+++ b/database.types.ts
@@ -4,338 +4,339 @@ export type Json =
   | boolean
   | null
   | { [key: string]: Json | undefined }
-  | Json[];
+  | Json[]
 
 export type Database = {
   // Allows to automatically instantiate createClient with right options
   // instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY)
   __InternalSupabase: {
-    PostgrestVersion: "13.0.4";
-  };
+    PostgrestVersion: "13.0.4"
+  }
   public: {
     Tables: {
       guesses: {
         Row: {
-          calculated_price: number;
-          created_at: string | null;
-          guessed_birth_date: string;
-          guessed_weight: number;
-          id: string;
-          is_anonymous: boolean;
-          name: string | null;
-          payment_id: string | null;
-          payment_status: string | null;
-          pool_id: string;
-          user_id: string;
-        };
+          calculated_price: number
+          created_at: string | null
+          guessed_birth_date: string
+          guessed_weight: number
+          id: string
+          is_anonymous: boolean
+          name: string | null
+          payment_id: string | null
+          payment_status: string | null
+          pool_id: string
+          user_id: string
+        }
         Insert: {
-          calculated_price: number;
-          created_at?: string | null;
-          guessed_birth_date: string;
-          guessed_weight: number;
-          id?: string;
-          is_anonymous?: boolean;
-          name?: string | null;
-          payment_id?: string | null;
-          payment_status?: string | null;
-          pool_id: string;
-          user_id: string;
-        };
+          calculated_price: number
+          created_at?: string | null
+          guessed_birth_date: string
+          guessed_weight: number
+          id?: string
+          is_anonymous?: boolean
+          name?: string | null
+          payment_id?: string | null
+          payment_status?: string | null
+          pool_id: string
+          user_id: string
+        }
         Update: {
-          calculated_price?: number;
-          created_at?: string | null;
-          guessed_birth_date?: string;
-          guessed_weight?: number;
-          id?: string;
-          is_anonymous?: boolean;
-          name?: string | null;
-          payment_id?: string | null;
-          payment_status?: string | null;
-          pool_id?: string;
-          user_id?: string;
-        };
+          calculated_price?: number
+          created_at?: string | null
+          guessed_birth_date?: string
+          guessed_weight?: number
+          id?: string
+          is_anonymous?: boolean
+          name?: string | null
+          payment_id?: string | null
+          payment_status?: string | null
+          pool_id?: string
+          user_id?: string
+        }
         Relationships: [
           {
-            foreignKeyName: "bets_pool_id_fkey";
-            columns: ["pool_id"];
-            isOneToOne: false;
-            referencedRelation: "pools";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
+            foreignKeyName: "bets_pool_id_fkey"
+            columns: ["pool_id"]
+            isOneToOne: false
+            referencedRelation: "pools"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       pools: {
         Row: {
-          actual_birth_date: string | null;
-          actual_birth_weight: number | null;
-          baby_name: string | null;
-          created_at: string | null;
-          description: string | null;
-          id: string;
-          image_url: string | null;
-          is_locked: boolean | null;
-          mu_due_date: string | null;
-          mu_weight: number;
-          organized_by: string | null;
-          organizer_image_url: string | null;
-          price_ceiling: number | null;
-          price_floor: number | null;
-          sigma_days: number | null;
-          sigma_weight: number | null;
-          slug: string;
-          stripe_account_id: string | null;
-          stripe_onboarding_complete: boolean;
-          user_id: string;
-          video_url: string | null;
-        };
+          actual_birth_date: string | null
+          actual_birth_weight: number | null
+          baby_name: string | null
+          created_at: string | null
+          description: string | null
+          id: string
+          image_url: string | null
+          is_locked: boolean | null
+          mu_due_date: string | null
+          mu_weight: number
+          organized_by: string | null
+          organizer_image_url: string | null
+          price_ceiling: number | null
+          price_floor: number | null
+          sigma_days: number | null
+          sigma_weight: number | null
+          slug: string
+          stripe_account_id: string | null
+          stripe_onboarding_complete: boolean
+          user_id: string
+          video_url: string | null
+        }
         Insert: {
-          actual_birth_date?: string | null;
-          actual_birth_weight?: number | null;
-          baby_name?: string | null;
-          created_at?: string | null;
-          description?: string | null;
-          id?: string;
-          image_url?: string | null;
-          is_locked?: boolean | null;
-          mu_due_date?: string | null;
-          mu_weight?: number;
-          organized_by?: string | null;
-          organizer_image_url?: string | null;
-          price_ceiling?: number | null;
-          price_floor?: number | null;
-          sigma_days?: number | null;
-          sigma_weight?: number | null;
-          slug: string;
-          stripe_account_id?: string | null;
-          stripe_onboarding_complete?: boolean;
-          user_id: string;
-          video_url?: string | null;
-        };
+          actual_birth_date?: string | null
+          actual_birth_weight?: number | null
+          baby_name?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          image_url?: string | null
+          is_locked?: boolean | null
+          mu_due_date?: string | null
+          mu_weight?: number
+          organized_by?: string | null
+          organizer_image_url?: string | null
+          price_ceiling?: number | null
+          price_floor?: number | null
+          sigma_days?: number | null
+          sigma_weight?: number | null
+          slug: string
+          stripe_account_id?: string | null
+          stripe_onboarding_complete?: boolean
+          user_id: string
+          video_url?: string | null
+        }
         Update: {
-          actual_birth_date?: string | null;
-          actual_birth_weight?: number | null;
-          baby_name?: string | null;
-          created_at?: string | null;
-          description?: string | null;
-          id?: string;
-          image_url?: string | null;
-          is_locked?: boolean | null;
-          mu_due_date?: string | null;
-          mu_weight?: number;
-          organized_by?: string | null;
-          organizer_image_url?: string | null;
-          price_ceiling?: number | null;
-          price_floor?: number | null;
-          sigma_days?: number | null;
-          sigma_weight?: number | null;
-          slug?: string;
-          stripe_account_id?: string | null;
-          stripe_onboarding_complete?: boolean;
-          user_id?: string;
-          video_url?: string | null;
-        };
-        Relationships: [];
-      };
+          actual_birth_date?: string | null
+          actual_birth_weight?: number | null
+          baby_name?: string | null
+          created_at?: string | null
+          description?: string | null
+          id?: string
+          image_url?: string | null
+          is_locked?: boolean | null
+          mu_due_date?: string | null
+          mu_weight?: number
+          organized_by?: string | null
+          organizer_image_url?: string | null
+          price_ceiling?: number | null
+          price_floor?: number | null
+          sigma_days?: number | null
+          sigma_weight?: number | null
+          slug?: string
+          stripe_account_id?: string | null
+          stripe_onboarding_complete?: boolean
+          user_id?: string
+          video_url?: string | null
+        }
+        Relationships: []
+      }
       rankings: {
         Row: {
-          created_at: string | null;
-          distance: number;
-          guess_id: string;
-          id: string;
-          pool_id: string;
-          rank: number;
-        };
+          created_at: string | null
+          distance: number
+          guess_id: string
+          id: string
+          pool_id: string
+          rank: number
+        }
         Insert: {
-          created_at?: string | null;
-          distance: number;
-          guess_id: string;
-          id?: string;
-          pool_id: string;
-          rank: number;
-        };
+          created_at?: string | null
+          distance: number
+          guess_id: string
+          id?: string
+          pool_id: string
+          rank: number
+        }
         Update: {
-          created_at?: string | null;
-          distance?: number;
-          guess_id?: string;
-          id?: string;
-          pool_id?: string;
-          rank?: number;
-        };
+          created_at?: string | null
+          distance?: number
+          guess_id?: string
+          id?: string
+          pool_id?: string
+          rank?: number
+        }
         Relationships: [
           {
-            foreignKeyName: "rankings_bet_id_fkey";
-            columns: ["guess_id"];
-            isOneToOne: false;
-            referencedRelation: "guesses";
-            referencedColumns: ["id"];
+            foreignKeyName: "rankings_bet_id_fkey"
+            columns: ["guess_id"]
+            isOneToOne: false
+            referencedRelation: "guesses"
+            referencedColumns: ["id"]
           },
           {
-            foreignKeyName: "rankings_pool_id_fkey";
-            columns: ["pool_id"];
-            isOneToOne: false;
-            referencedRelation: "pools";
-            referencedColumns: ["id"];
-          }
-        ];
-      };
-    };
+            foreignKeyName: "rankings_pool_id_fkey"
+            columns: ["pool_id"]
+            isOneToOne: false
+            referencedRelation: "pools"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+    }
     Views: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     Functions: {
       create_guess_from_webhook: {
         Args: {
-          p_pool_id: string;
-          p_user_id: string;
-          p_guessed_birth_date: string;
-          p_guessed_weight: number;
-          p_calculated_price: number;
-          p_payment_id: string;
-          p_name: string;
-          p_is_anonymous: boolean;
-        };
-        Returns: Json;
-      };
-      mark_pool_stripe_connected: {
-        Args: { p_stripe_account_id: string };
-        Returns: undefined;
-      };
+          p_calculated_price: number
+          p_guessed_birth_date: string
+          p_guessed_weight: number
+          p_is_anonymous: boolean
+          p_name: string
+          p_payment_id: string
+          p_pool_id: string
+          p_user_id: string
+        }
+        Returns: Json
+      }
       get_pool_connect_info: {
-        Args: { p_pool_id: string };
-        Returns: { slug: string; stripe_account_id: string | null }[];
-      };
-    };
+        Args: { p_pool_id: string }
+        Returns: {
+          slug: string
+          stripe_account_id: string
+        }[]
+      }
+      mark_guess_refunded: { Args: { p_payment_id: string }; Returns: Json }
+      mark_pool_stripe_connected: {
+        Args: { p_stripe_account_id: string }
+        Returns: undefined
+      }
+    }
     Enums: {
-      [_ in never]: never;
-    };
+      [_ in never]: never
+    }
     CompositeTypes: {
-      [_ in never]: never;
-    };
-  };
-};
+      [_ in never]: never
+    }
+  }
+}
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">;
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<
-  keyof Database,
-  "public"
->];
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
     | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
         DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
-    : never = never
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
       DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R;
+      Row: infer R
     }
     ? R
     : never
   : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-      DefaultSchema["Views"])
-  ? (DefaultSchema["Tables"] &
-      DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
-      Row: infer R;
-    }
-    ? R
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+        Row: infer R
+      }
+      ? R
+      : never
     : never
-  : never;
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I;
+      Insert: infer I
     }
     ? I
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-  ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-      Insert: infer I;
-    }
-    ? I
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Insert: infer I
+      }
+      ? I
+      : never
     : never
-  : never;
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
     | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
-    : never = never
+    : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U;
+      Update: infer U
     }
     ? U
     : never
   : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-  ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
-      Update: infer U;
-    }
-    ? U
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+        Update: infer U
+      }
+      ? U
+      : never
     : never
-  : never;
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
     | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
-    : never = never
+    : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-  ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
-  : never;
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+    : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
     | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
-    schema: keyof DatabaseWithoutInternals;
+    schema: keyof DatabaseWithoutInternals
   }
     ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
-    : never = never
+    : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
-  schema: keyof DatabaseWithoutInternals;
+  schema: keyof DatabaseWithoutInternals
 }
   ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
   : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-  ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
-  : never;
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+    : never
 
 export const Constants = {
   public: {
     Enums: {},
   },
-} as const;
+} as const

--- a/supabase/migrations/004_refund_webhook.sql
+++ b/supabase/migrations/004_refund_webhook.sql
@@ -1,0 +1,29 @@
+-- Migration: mark guesses as refunded when Stripe fires charge.refunded
+-- Keeps the guess row for audit/history; payment_status flips to 'refunded'
+-- so totals and rankings can exclude it.
+
+CREATE OR REPLACE FUNCTION mark_guess_refunded(p_payment_id text)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_result guesses%ROWTYPE;
+BEGIN
+  UPDATE guesses
+  SET payment_status = 'refunded'
+  WHERE payment_id = p_payment_id
+  RETURNING * INTO v_result;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No guess found for payment: %', p_payment_id;
+  END IF;
+
+  RETURN row_to_json(v_result);
+END;
+$$;
+
+-- Anon role needs EXECUTE (the webhook uses the anon key)
+GRANT EXECUTE ON FUNCTION mark_guess_refunded(text) TO anon;
+GRANT EXECUTE ON FUNCTION mark_guess_refunded(text) TO authenticated;


### PR DESCRIPTION
Refunding in the Stripe dashboard used to leave the guess row saying 'paid' forever — DB/Stripe mismatch.

- New `charge.refunded` webhook handler → `mark_guess_refunded` RPC (migration 004, already applied to prod DB) flips `payment_status` to `'refunded'`. Row stays for audit history.
- Donation total on pool pages excludes refunded guesses.

**One manual step after merge:** add `charge.refunded` to the live webhook endpoint's events (Stripe Dashboard → Webhooks → guess-purchase → Edit destination). Test locally with `stripe trigger charge.refunded`.