### PR TITLE
Exclude refunded guesses from rankings

### DIFF
--- a/app/baby/[slug]/page.tsx
+++ b/app/baby/[slug]/page.tsx
@@ -20,7 +20,9 @@ export default async function BabyPoolPage({
     return notFound();
   }
 
-  const guesses = await getGuessesForPool(pool.id);
+  const guesses = await getGuessesForPool(pool.id, {
+    includeRefunded: true,
+  });
 
   // Get user on server side
   const supabase = await createClient();

--- a/lib/data/guesses/getGuessesForPool.ts
+++ b/lib/data/guesses/getGuessesForPool.ts
@@ -2,14 +2,24 @@ import { createClient } from "@/lib/supabase/server";
 import { Tables } from "@/database.types";
 
 export async function getGuessesForPool(
-  poolId: string
+  poolId: string,
+  opts: { includeRefunded?: boolean } = {}
 ): Promise<Tables<"guesses">[]> {
   const supabase = await createClient();
-  const { data, error } = await supabase
+  let query = supabase
     .from("guesses")
     .select("*")
     .eq("pool_id", poolId)
     .order("created_at", { ascending: false });
+
+  // By default, refunded guesses don't count — a refunded donation isn't a
+  // donation. Ranking (closePool) and all public views exclude them. The
+  // pool page passes includeRefunded so the owner can see the audit trail.
+  if (!opts.includeRefunded) {
+    query = query.neq("payment_status", "refunded");
+  }
+
+  const { data, error } = await query;
   if (error) {
     console.error("Error fetching guesses:", error);
     return [];


### PR DESCRIPTION
Closes the edge case where a refunded guess could win the pool. getGuessesForPool excludes refunded rows by default (used by closePool + live rankings); the pool page opts in to see them for the owner audit view.