### PR TITLE
Refunds return 100% including platform fee

### DIFF
--- a/components/blocks/faq.tsx
+++ b/components/blocks/faq.tsx
@@ -127,7 +127,8 @@ const faqs: Faq[] = [
       <p>
         If you made a guess by mistake, contact the pool creator — they can
         refund any guess on their pool straight from their pool page (it&apos;s
-        instant and irreversible). Pool creators: open your pool, find the
+        instant and irreversible). You always get 100% of your donation back,
+        including the platform fee. Pool creators: open your pool, find the
         guess in the table, and hit Refund.
       </p>
     ),

--- a/lib/actions/baby/refundGuess.ts
+++ b/lib/actions/baby/refundGuess.ts
@@ -64,6 +64,11 @@ export async function refundGuess(
   try {
     await stripe.refunds.create({
       payment_intent: guess.payment_id,
+      // Return the platform's application fee as well, so the guesser is
+      // refunded 100% of their donation. The platform eats Stripe's
+      // processing fee on refunds — that's our cost of doing business,
+      // not the guesser's or creator's problem.
+      refund_application_fee: true,
     });
     // The charge.refunded webhook flips payment_status to 'refunded'
     // (usually within a second). Revalidate so the table updates.


### PR DESCRIPTION
Dashboard refunds leave the application fee with the platform by default — the fee row showed 'Collected' because it genuinely wasn't refunded. Now creator-initiated refunds pass refund_application_fee: true so guessers get every cent back. FAQ promises 100%.