### PR TITLE
Improve create-pool form validation UX

### DIFF
--- a/components/ui/baby/create-form.tsx
+++ b/components/ui/baby/create-form.tsx
@@ -2,11 +2,17 @@
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import {
+  RequiredMark,
+  OptionalMark,
+  FieldError,
+} from "@/components/ui/form-field";
 import { CardContent, CardFooter } from "@/components/ui/card";
 import { useActionState } from "react";
 import { toast } from "sonner";
 import { useEffect, useState, useRef, useCallback } from "react";
 import clsx from "clsx";
+import { CircleAlert, CircleCheck, LoaderCircle } from "lucide-react";
 import { formatSlug, generateSlugSuggestions } from "@/lib/helpers/slug";
 import { getVideoEmbed } from "@/lib/helpers/videoEmbed";
 import { GaussianCurve } from "@/components/ui/baby/gaussian-curve";
@@ -28,6 +34,26 @@ import {
 import { LoadingSpinner } from "@/components/ui/loading-spinner";
 import Image from "next/image";
 
+type FieldKey =
+  | "baby_name"
+  | "organized_by"
+  | "slug"
+  | "description"
+  | "due_date"
+  | "price_floor"
+  | "price_ceiling"
+  | "video_url"
+  | "image"
+  | "organizer_image";
+
+type FieldErrors = Partial<Record<FieldKey, string>>;
+
+/** Destructive ring/border treatment for invalid fields (design-system tokens). */
+const invalidInputClass =
+  "border-destructive focus-visible:ring-destructive";
+
+const errorSummaryTitleId = "create-pool-error-summary-title";
+
 export function CreateBabyPoolForm() {
   // --- State ---
   // Form fields
@@ -36,7 +62,6 @@ export function CreateBabyPoolForm() {
   const [dueDate, setDueDate] = useState("");
   const [description, setDescription] = useState("");
   const [videoUrl, setVideoUrl] = useState("");
-  const [videoTouched, setVideoTouched] = useState(false);
   const trimmedVideoUrl = videoUrl.trim();
   const videoEmbed = trimmedVideoUrl ? getVideoEmbed(trimmedVideoUrl) : null;
   const videoUrlValid = trimmedVideoUrl === "" || videoEmbed !== null;
@@ -68,6 +93,142 @@ export function CreateBabyPoolForm() {
   // Price validation
   const [priceError, setPriceError] = useState<string | null>(null);
   const debounceRef = useRef<NodeJS.Timeout | null>(null);
+
+  // --- Validation state ---
+  // "Reward early, punish late": a field first validates on blur; once it has
+  // an error it re-validates on every change so the error clears as soon as
+  // it's fixed. `submitAttempt` increments on each failed submit and forces
+  // all fields to show their errors (a counter, so re-submitting after a
+  // failed attempt still re-renders and moves focus).
+  const [touched, setTouched] = useState<Partial<Record<FieldKey, boolean>>>(
+    {}
+  );
+  const [submitAttempt, setSubmitAttempt] = useState(0);
+  const [serverErrors, setServerErrors] = useState<FieldErrors>({});
+  const errorSummaryRef = useRef<HTMLDivElement | null>(null);
+  const fieldRefs = useRef<Partial<Record<FieldKey, HTMLElement | null>>>({});
+
+  const markTouched = useCallback((field: FieldKey) => {
+    setTouched((prev) => (prev[field] ? prev : { ...prev, [field]: true }));
+  }, []);
+
+  // --- Client validators (run on every render from current field state) ---
+  const clientFieldError = useCallback(
+    (field: FieldKey): string | null => {
+      switch (field) {
+        case "baby_name":
+          return babyName.trim() ? null : "Enter the baby's name.";
+        case "organized_by":
+          return organizedBy.trim()
+            ? null
+            : "Enter who is organizing this pool.";
+        case "description":
+          if (!description.trim())
+            return "Write a short description of the pool.";
+          if (description.length > 1000)
+            return "Description must be 1000 characters or fewer.";
+          return null;
+        case "due_date":
+          return dueDate ? null : "Select the expected due date.";
+        case "price_floor":
+          return typeof minPrice === "number"
+            ? null
+            : "Enter a minimum guess price.";
+        case "price_ceiling":
+          return typeof maxPrice === "number"
+            ? null
+            : "Enter a maximum guess price.";
+        case "video_url":
+          return videoUrlValid
+            ? null
+            : "Unrecognized video link. Paste a YouTube or Vimeo URL, or leave it blank.";
+        default:
+          return null;
+      }
+    },
+    [
+      babyName,
+      organizedBy,
+      description,
+      dueDate,
+      minPrice,
+      maxPrice,
+      videoUrlValid,
+    ]
+  );
+
+  // Cross-field: max price must exceed min price. Shown once, under the
+  // ceiling input, on blur of either price field.
+  const priceRelationError =
+    typeof minPrice === "number" &&
+    typeof maxPrice === "number" &&
+    maxPrice <= minPrice
+      ? "Maximum price must be greater than minimum price."
+      : null;
+
+  const getVisibleError = useCallback(
+    (field: FieldKey): string | null => {
+      const visible = submitAttempt > 0 || touched[field];
+      if (!visible) return null;
+      // Cross-field and async errors are only shown while their field is in
+      // a visible state too.
+      if (field === "slug") return slugError || serverErrors.slug || null;
+      if (field === "price_ceiling")
+        return (
+          clientFieldError("price_ceiling") ||
+          priceRelationError ||
+          priceError ||
+          serverErrors.price_ceiling ||
+          null
+        );
+      if (field === "price_floor")
+        return clientFieldError("price_floor") || serverErrors.price_floor || null;
+      if (field === "image") return serverErrors.image || null;
+      if (field === "organizer_image")
+        return serverErrors.organizer_image || null;
+      return clientFieldError(field) || serverErrors[field] || null;
+    },
+    [
+      submitAttempt,
+      touched,
+      clientFieldError,
+      slugError,
+      priceRelationError,
+      priceError,
+      serverErrors,
+    ]
+  );
+
+  // --- Form validity (drives the summary and the submit guard) ---
+  const formErrors: FieldErrors = {};
+  (
+    [
+      "baby_name",
+      "organized_by",
+      "slug",
+      "description",
+      "due_date",
+      "price_floor",
+      "price_ceiling",
+      "video_url",
+    ] as FieldKey[]
+  ).forEach((field) => {
+    const err =
+      field === "price_ceiling"
+        ? clientFieldError("price_ceiling") || priceRelationError
+        : field === "slug"
+          ? slugError || serverErrors.slug
+          : clientFieldError(field);
+    if (err) formErrors[field] = err;
+  });
+  // A slug that hasn't been confirmed available blocks submission, but the
+  // empty-slug message is friendlier than "still checking".
+  if (!formErrors.slug && slug.trim() && slugAvailable !== true) {
+    formErrors.slug = slugChecking
+      ? "We're still checking this URL — wait a moment."
+      : "This URL isn't available. Please choose another.";
+  }
+  const isFormValid = Object.keys(formErrors).length === 0;
 
   // --- Handlers ---
   // Image upload handler
@@ -133,29 +294,49 @@ export function CreateBabyPoolForm() {
     initialState
   );
 
-  // All fields are required except images and video. Weight and pricing
-  // model always have valid defaults, so they don't need checks here.
-  const pricesValid =
-    typeof minPrice === "number" &&
-    typeof maxPrice === "number" &&
-    maxPrice > minPrice;
-  const isFormValid =
-    babyName.trim() !== "" &&
-    organizedBy.trim() !== "" &&
-    slug.trim() !== "" &&
-    slugAvailable === true &&
-    description.trim() !== "" &&
-    dueDate !== "" &&
-    pricesValid &&
-    videoUrlValid;
   const isSubmitDisabled =
-    isPending || imageProcessing || organizerImageProcessing || !isFormValid;
+    isPending || imageProcessing || organizerImageProcessing;
+
+  // --- Focus helpers ---
+  const focusField = (field: FieldKey) => {
+    const el = fieldRefs.current[field];
+    if (!el) return;
+    el.scrollIntoView({ behavior: "smooth", block: "center" });
+    el.focus({ preventScroll: true });
+  };
 
   // --- Effects ---
-  // Toast error on state.message
+  // Move focus to the error summary whenever a new validation round mounts
+  // it (GOV.UK error-summary pattern). Runs after the DOM update, so no
+  // timing hacks are needed.
   useEffect(() => {
+    if (submitAttempt > 0 && errorSummaryRef.current) {
+      errorSummaryRef.current.focus();
+      errorSummaryRef.current.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  }, [submitAttempt]);
+
+  // On server response: map field errors inline, toast the form-level
+  // message, and move focus to the error summary.
+  useEffect(() => {
+    if (!state?.message && !state?.errors) return;
     if (state?.message) {
       toast.error(state.message);
+    }
+    if (state?.errors && Object.keys(state.errors).length > 0) {
+      const mapped: FieldErrors = {};
+      for (const [field, messages] of Object.entries(state.errors)) {
+        if (messages?.[0]) mapped[field as FieldKey] = messages[0];
+      }
+      setServerErrors(mapped);
+    }
+    if (state?.message) {
+      // Increment (not just set) so the focus effect fires even when the
+      // form was already in an attempted state.
+      setSubmitAttempt((n) => n + 1);
     }
   }, [state]);
 
@@ -222,46 +403,98 @@ export function CreateBabyPoolForm() {
   const getSafeMinPrice = () => (typeof minPrice === "number" ? minPrice : 1);
   const getSafeMaxPrice = () => (typeof maxPrice === "number" ? maxPrice : 50);
 
+  const errorEntries = Object.entries(formErrors) as [FieldKey, string][];
+
+  // We handle validation ourselves (inline errors + summary), so the form
+  // uses noValidate to suppress native bubbles, which would appear
+  // one-at-a-time at odd times.
   return (
     <form
+      noValidate
       action={(formData) => {
         if (!isFormValid) {
-          toast.error("Please fill out all required fields.");
+          // Bump the attempt counter — the summary + inline errors render
+          // and the focus effect moves to the summary.
+          setSubmitAttempt((n) => n + 1);
+          toast.error("Please fix the fields highlighted below.");
           return;
         }
-        // Ensure we have valid price values before submission
-        // Prevent submit if min/max relationship is invalid
-        if (
-          typeof minPrice === "number" &&
-          typeof maxPrice === "number" &&
-          maxPrice <= minPrice
-        ) {
-          setPriceError("Maximum price must be greater than minimum price");
-          toast.error("Maximum price must be greater than minimum price");
-          return;
-        }
-
+        setServerErrors({});
         formAction(formData);
       }}
     >
       <CardContent>
         <div className="space-y-6">
+          <p className="text-xs text-muted-foreground">
+            Fields marked with <RequiredMark /> are required.
+          </p>
+
+          {/* Error summary (GOV.UK pattern): rendered on a failed submit
+              attempt or when the server rejects the form. Each item links to
+              and focuses its field. */}
+          {(submitAttempt > 0 || state?.message) &&
+            (errorEntries.length > 0 || state?.message) && (
+              <div
+                ref={errorSummaryRef}
+                tabIndex={-1}
+                role="alert"
+                aria-labelledby={errorSummaryTitleId}
+                className="rounded-md border border-destructive/50 bg-destructive/5 p-4 focus:outline-none"
+              >
+                <h2
+                  id={errorSummaryTitleId}
+                  className="text-sm font-semibold text-destructive"
+                >
+                  There is a problem
+                </h2>
+                <ul className="mt-2 space-y-1">
+                  {errorEntries.map(([field, message]) => (
+                    <li key={field} className="text-xs">
+                      <button
+                        type="button"
+                        onClick={() => focusField(field)}
+                        className="flex items-start gap-1 text-left text-destructive underline underline-offset-2 hover:text-destructive/80"
+                      >
+                        <CircleAlert
+                          className="mt-px h-3.5 w-3.5 shrink-0"
+                          aria-hidden="true"
+                        />
+                        <span>{message}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           <div>
             <Label
               htmlFor="baby_name"
               className="text-base font-semibold tracking-tight"
             >
               Baby Name
+              <RequiredMark />
             </Label>
             <Input
+              ref={(el) => {
+                fieldRefs.current.baby_name = el;
+              }}
               id="baby_name"
               name="baby_name"
               value={babyName}
               onChange={(e) => setBabyName(e.target.value)}
+              onBlur={() => markTouched("baby_name")}
               placeholder="e.g. Baby Smith"
               required
-              className="rounded"
+              className={clsx(
+                "rounded mt-2",
+                getVisibleError("baby_name") && invalidInputClass
+              )}
+              aria-invalid={!!getVisibleError("baby_name")}
+              aria-describedby={
+                getVisibleError("baby_name") ? "baby_name-error" : undefined
+              }
             />
+            <FieldError id="baby_name-error" message={getVisibleError("baby_name")} />
           </div>
           <div>
             <Label
@@ -269,15 +502,33 @@ export function CreateBabyPoolForm() {
               className="text-base font-semibold tracking-tight"
             >
               Organized By
+              <RequiredMark />
             </Label>
             <Input
+              ref={(el) => {
+                fieldRefs.current.organized_by = el;
+              }}
               id="organized_by"
               name="organized_by"
               value={organizedBy}
               onChange={(e) => setOrganizedBy(e.target.value)}
+              onBlur={() => markTouched("organized_by")}
               placeholder="e.g. Heather & Keegan"
               required
-              className="rounded"
+              className={clsx(
+                "rounded mt-2",
+                getVisibleError("organized_by") && invalidInputClass
+              )}
+              aria-invalid={!!getVisibleError("organized_by")}
+              aria-describedby={
+                getVisibleError("organized_by")
+                  ? "organized_by-error"
+                  : undefined
+              }
+            />
+            <FieldError
+              id="organized_by-error"
+              message={getVisibleError("organized_by")}
             />
           </div>
           <div>
@@ -286,25 +537,49 @@ export function CreateBabyPoolForm() {
               className="text-base font-semibold tracking-tight"
             >
               Pool Slug
+              <RequiredMark />
             </Label>
             <p className="text-xs text-gray-500">
               This will be part of the shareable URL for your pool. Must be
               unique and can only contain lowercase letters and numbers.
             </p>
             <Input
+              ref={(el) => {
+                fieldRefs.current.slug = el;
+              }}
               id="slug"
               name="slug"
               value={slug}
               onChange={(e) => {
                 const formatted = formatSlug(e.target.value);
                 setSlug(formatted);
+                // Choosing/typing a new slug clears any stale server error.
+                setServerErrors((prev) =>
+                  prev.slug ? { ...prev, slug: undefined } : prev
+                );
               }}
+              onBlur={() => markTouched("slug")}
               placeholder="e.g. babymario"
               required
               className={clsx(
                 "rounded",
-                slugAvailable === false && "border-red-500 focus:border-red-500"
+                (getVisibleError("slug") ||
+                  (touched.slug && slug && slugAvailable === false)) &&
+                  invalidInputClass
               )}
+              aria-invalid={
+                !!(
+                  getVisibleError("slug") ||
+                  (touched.slug && slug && slugAvailable === false)
+                )
+              }
+              aria-describedby={
+                getVisibleError("slug")
+                  ? "slug-error"
+                  : slug && slugAvailable === true
+                    ? "slug-success"
+                    : undefined
+              }
               autoComplete="off"
             />
             {/* Muted preview of shareable URL */}
@@ -318,14 +593,25 @@ export function CreateBabyPoolForm() {
                 : ""}
             </div>
             {/* Slug validation feedback */}
-            {slugChecking && (
-              <div className="text-xs text-gray-400 mt-1">
+            {slugChecking && slug && (
+              <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1">
+                <LoaderCircle
+                  className="h-3.5 w-3.5 animate-spin"
+                  aria-hidden="true"
+                />
                 Checking availability...
               </div>
             )}
-            {slugError && (
-              <div className="text-xs text-red-500 mt-1">{slugError}</div>
+            {!slugChecking && slug && slugAvailable === true && (
+              <div
+                id="slug-success"
+                className="flex items-center gap-1 text-xs text-green-600 mt-1"
+              >
+                <CircleCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                This URL is available.
+              </div>
             )}
+            <FieldError id="slug-error" message={getVisibleError("slug")} />
             {/* Slug suggestions */}
             {slugAvailable === false && slugSuggestions.length > 0 && (
               <div className="text-xs text-gray-500 mt-1 flex flex-wrap gap-2">
@@ -342,23 +628,25 @@ export function CreateBabyPoolForm() {
                 ))}
               </div>
             )}
-          </div>
-          {/* Image Upload Drop Zone */}
+          </div>          {/* Image Upload Drop Zone */}
           <div>
             <Label
               htmlFor="image_upload"
               className="text-base font-semibold tracking-tight"
             >
               Baby Image (Ultrasound)
+              <OptionalMark />
             </Label>
             <div
               className={clsx(
                 "border-2 border-dashed rounded-md p-4 mt-2 flex flex-col items-center justify-center cursor-pointer transition",
                 imageDragActive
                   ? "border-blue-400 bg-blue-50"
-                  : imagePreview
-                    ? "border-green-400"
-                    : "border-gray-300 hover:border-blue-400"
+                  : getVisibleError("image")
+                    ? "border-destructive"
+                    : imagePreview
+                      ? "border-green-400"
+                      : "border-gray-300 hover:border-blue-400"
               )}
               onDragOver={(e) => {
                 e.preventDefault();
@@ -423,6 +711,9 @@ export function CreateBabyPoolForm() {
                 Choose Image
               </Button>
               <input
+                ref={(el) => {
+                  fieldRefs.current.image = el;
+                }}
                 id="image_upload"
                 name="image"
                 type="file"
@@ -444,6 +735,7 @@ export function CreateBabyPoolForm() {
                 Processing image...
               </div>
             )}
+            <FieldError id="image-error" message={getVisibleError("image")} />
             <p className="text-xs text-gray-500 mt-1">
               Optional. Recommended size: square, under 400kB.
             </p>
@@ -456,15 +748,18 @@ export function CreateBabyPoolForm() {
               className="text-base font-semibold tracking-tight"
             >
               Organizer Image
+              <OptionalMark />
             </Label>
             <div
               className={clsx(
                 "border-2 border-dashed rounded-md p-4 mt-2 flex flex-col items-center justify-center cursor-pointer transition",
                 organizerDragActive
                   ? "border-blue-400 bg-blue-50"
-                  : organizerImagePreview
-                    ? "border-green-400"
-                    : "border-gray-300 hover:border-blue-400"
+                  : getVisibleError("organizer_image")
+                    ? "border-destructive"
+                    : organizerImagePreview
+                      ? "border-green-400"
+                      : "border-gray-300 hover:border-blue-400"
               )}
               onDragOver={(e) => {
                 e.preventDefault();
@@ -529,6 +824,9 @@ export function CreateBabyPoolForm() {
                 Choose Organizer Image
               </Button>
               <input
+                ref={(el) => {
+                  fieldRefs.current.organizer_image = el;
+                }}
                 id="organizer_image_upload"
                 name="organizer_image"
                 type="file"
@@ -550,29 +848,50 @@ export function CreateBabyPoolForm() {
                 Processing image...
               </div>
             )}
+            <FieldError
+              id="organizer_image-error"
+              message={getVisibleError("organizer_image")}
+            />
             <p className="text-xs text-gray-500 mt-1">
               Optional. Photo of the organizer(s). Recommended size: square,
               under 400kB.
             </p>
-          </div>
-
-          {/* Description Textarea */}
+          </div>          {/* Description Textarea */}
           <div>
             <Label
               htmlFor="description"
               className="text-base font-semibold tracking-tight"
             >
               Pool Description
+              <RequiredMark />
             </Label>
             <textarea
+              ref={(el) => {
+                fieldRefs.current.description = el;
+              }}
               id="description"
               name="description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
+              onBlur={() => markTouched("description")}
               placeholder="Write something about this baby pool..."
               rows={4}
-              className="w-full mt-2 border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 bg-input-background"
+              required
+              className={clsx(
+                "w-full mt-2 border rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400 bg-input-background",
+                getVisibleError("description") && invalidInputClass
+              )}
               maxLength={1000}
+              aria-invalid={!!getVisibleError("description")}
+              aria-describedby={
+                getVisibleError("description")
+                  ? "description-error"
+                  : undefined
+              }
+            />
+            <FieldError
+              id="description-error"
+              message={getVisibleError("description")}
             />
             <div className="text-xs text-gray-400 mt-1">
               {description.length}/1000 characters
@@ -589,38 +908,42 @@ export function CreateBabyPoolForm() {
               htmlFor="video_url"
               className="text-base font-semibold tracking-tight"
             >
-              Video (optional)
+              Video
+              <OptionalMark />
             </Label>
             <Input
+              ref={(el) => {
+                fieldRefs.current.video_url = el;
+              }}
               id="video_url"
               name="video_url"
               type="url"
               inputMode="url"
               value={videoUrl}
-              onChange={(e) => {
-                setVideoUrl(e.target.value);
-                setVideoTouched(true);
-              }}
+              onChange={(e) => setVideoUrl(e.target.value)}
+              onBlur={() => markTouched("video_url")}
               placeholder="https://www.youtube.com/watch?v=..."
               className={clsx(
                 "rounded mt-2",
-                !videoUrlValid && "border-red-400 focus-visible:ring-red-400"
+                getVisibleError("video_url") && invalidInputClass
               )}
-              aria-invalid={!videoUrlValid}
+              aria-invalid={!!getVisibleError("video_url")}
+              aria-describedby={
+                getVisibleError("video_url") ? "video_url-error" : undefined
+              }
             />
-            {!videoUrlValid && (
-              <p className="text-xs text-red-500 mt-1">
-                We can&apos;t recognize that link. Paste a YouTube or Vimeo URL
-                (e.g. https://www.youtube.com/watch?v=...) or leave it blank.
-              </p>
-            )}
+            <FieldError
+              id="video_url-error"
+              message={getVisibleError("video_url")}
+            />
             {videoUrlValid && videoEmbed && (
-              <p className="text-xs text-green-600 mt-1">
-                ✓ {videoEmbed.provider === "youtube" ? "YouTube" : "Vimeo"}{" "}
-                video recognized — it will be embedded on your pool page.
+              <p className="flex items-center gap-1 text-xs text-green-600 mt-1">
+                <CircleCheck className="h-3.5 w-3.5" aria-hidden="true" />
+                {videoEmbed.provider === "youtube" ? "YouTube" : "Vimeo"} video
+                recognized — it will be embedded on your pool page.
               </p>
             )}
-            {!(videoTouched && trimmedVideoUrl) && (
+            {!trimmedVideoUrl && (
               <p className="text-xs text-gray-500 mt-1">
                 Add a YouTube or Vimeo link and it will be embedded on your
                 pool page. The video stays hosted there — we don&apos;t store
@@ -647,22 +970,43 @@ export function CreateBabyPoolForm() {
                   className="text-base font-semibold tracking-tight"
                 >
                   Expected Due Date
+                  <RequiredMark />
                 </Label>
-                <DatePicker
-                  id="due_date"
-                  value={dueDate}
-                  onChange={setDueDate}
-                  placeholder="Select the expected due date"
-                  className="mt-2"
-                />
+                <div
+                  ref={(el) => {
+                    fieldRefs.current.due_date = el;
+                  }}
+                  tabIndex={-1}
+                  className="focus:outline-none"
+                >
+                  <DatePicker
+                    id="due_date"
+                    value={dueDate}
+                    onChange={(value) => {
+                      setDueDate(value);
+                      markTouched("due_date");
+                    }}
+                    placeholder="Select the expected due date"
+                    className={clsx(
+                      "mt-2",
+                      getVisibleError("due_date") && invalidInputClass
+                    )}
+                  />
+                </div>
                 {/* Submitted with the form; value format matches the old
                     input[type=date] (yyyy-mm-dd) so the server action is
-                    unchanged. `required` preserves native validation. */}
-                <input type="hidden" name="due_date" value={dueDate} required />
+                    unchanged. Validation is handled in React (the form uses
+                    noValidate). */}
+                <input type="hidden" name="due_date" value={dueDate} />
+                <FieldError
+                  id="due_date-error"
+                  message={getVisibleError("due_date")}
+                />
               </div>
               <div className="flex-1">
                 <Label className="text-base font-semibold tracking-tight">
                   Expected Weight
+                  <RequiredMark />
                 </Label>
                 <WeightSexSelector
                   className="mt-2 max-w-sm"
@@ -732,11 +1076,15 @@ export function CreateBabyPoolForm() {
                   className="text-base font-semibold tracking-tight"
                 >
                   Minimum Guess Price ($)
+                  <RequiredMark />
                 </Label>
                 <p className="text-xs text-muted-foreground">
                   The price at the edges of the statistical range.
                 </p>
                 <Input
+                  ref={(el) => {
+                    fieldRefs.current.price_floor = el;
+                  }}
                   id="price_floor"
                   name="price_floor"
                   type="number"
@@ -772,6 +1120,7 @@ export function CreateBabyPoolForm() {
                     }
                   }}
                   onBlur={(e) => {
+                    markTouched("price_floor");
                     // If field is empty on blur, set to default
                     if (e.target.value === "") {
                       setMinPrice(DEFAULT_PRICE_FLOOR);
@@ -791,7 +1140,20 @@ export function CreateBabyPoolForm() {
                   }}
                   placeholder="5"
                   required
-                  className="rounded mt-2 px-4"
+                  className={clsx(
+                    "rounded mt-2 px-4",
+                    getVisibleError("price_floor") && invalidInputClass
+                  )}
+                  aria-invalid={!!getVisibleError("price_floor")}
+                  aria-describedby={
+                    getVisibleError("price_floor")
+                      ? "price_floor-error"
+                      : undefined
+                  }
+                />
+                <FieldError
+                  id="price_floor-error"
+                  message={getVisibleError("price_floor")}
                 />
               </div>
               <div>
@@ -800,11 +1162,15 @@ export function CreateBabyPoolForm() {
                   className="text-base font-semibold tracking-tight"
                 >
                   Maximum Guess Price ($)
+                  <RequiredMark />
                 </Label>
                 <p className="text-xs text-muted-foreground">
                   The price for guessing the most statistically likely outcome.
                 </p>
                 <Input
+                  ref={(el) => {
+                    fieldRefs.current.price_ceiling = el;
+                  }}
                   id="price_ceiling"
                   name="price_ceiling"
                   type="number"
@@ -836,6 +1202,7 @@ export function CreateBabyPoolForm() {
                     }
                   }}
                   onBlur={(e) => {
+                    markTouched("price_ceiling");
                     // If field is empty on blur, set to default
                     if (e.target.value === "") {
                       setMaxPrice(DEFAULT_PRICE_CEILING);
@@ -855,12 +1222,23 @@ export function CreateBabyPoolForm() {
                   }}
                   placeholder="50"
                   required
-                  className="rounded mt-2 w-full"
+                  className={clsx(
+                    "rounded mt-2 w-full",
+                    getVisibleError("price_ceiling") && invalidInputClass
+                  )}
+                  aria-invalid={!!getVisibleError("price_ceiling")}
+                  aria-describedby={
+                    getVisibleError("price_ceiling")
+                      ? "price_ceiling-error"
+                      : undefined
+                  }
                 />
-                {/* Inline validation message for the price inputs */}
-                {priceError && (
-                  <div className="text-xs text-red-500 mt-2">{priceError}</div>
-                )}
+                {/* Inline validation message for the price inputs, including
+                    the cross-field "max must exceed min" rule */}
+                <FieldError
+                  id="price_ceiling-error"
+                  message={getVisibleError("price_ceiling")}
+                />
               </div>
             </div>
             <p className="text-xs text-muted-foreground">
@@ -870,8 +1248,7 @@ export function CreateBabyPoolForm() {
               {Math.round(PLATFORM_FEE_PERCENT * 100)}% platform fee, and
               standard card processing applies.
             </p>
-          </div>
-          {/* Pricing Model Selection */}
+          </div>          {/* Pricing Model Selection */}
           <div>
             <label className="font-semibold text-base tracking-tight">
               Select Pricing Model (Sigma Behavior)
@@ -974,6 +1351,10 @@ export function CreateBabyPoolForm() {
         <input type="hidden" name="slug" value={slug} />
       </CardContent>
       <CardFooter className="p-8 pt-0 flex-col items-stretch">
+        {/* The submit button stays enabled while editing: clicking it runs
+            validation and points at what's missing (NN/g guidance — a
+            disabled button leaves users guessing). It is only disabled while
+            a submission or image processing is actually in flight. */}
         <Button
           type="submit"
           size="lg"
@@ -995,12 +1376,6 @@ export function CreateBabyPoolForm() {
             "Create Pool"
           )}
         </Button>
-        {!isFormValid && (
-          <p className="text-xs text-muted-foreground text-center mt-2">
-            Fill out all required fields (including an available pool URL) to
-            create your pool.
-          </p>
-        )}
       </CardFooter>
     </form>
   );

--- a/components/ui/form-field.tsx
+++ b/components/ui/form-field.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import { CircleAlert } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export function RequiredMark() {
+  // aria-hidden: the input itself carries `required`, which is what assistive
+  // tech announces — the visual asterisk would be read as punctuation.
+  return (
+    <span className="text-destructive" aria-hidden="true">
+      {" "}*
+    </span>
+  );
+}
+
+export function OptionalMark() {
+  return (
+    <span className="text-muted-foreground font-normal text-xs">
+      {" "}(optional)
+    </span>
+  );
+}
+
+export interface FieldErrorProps extends React.ComponentProps<"p"> {
+  /** Render nothing when falsy so callers can pass the message directly. */
+  message?: string | null;
+}
+
+/**
+ * Inline error message for form fields. Not color-alone (WCAG 1.4.1): pairs
+ * destructive text with an alert icon. Link from the input via aria-describedby.
+ */
+export function FieldError({ id, message, className, ...props }: FieldErrorProps) {
+  if (!message) return null;
+  return (
+    <p
+      id={id}
+      className={cn("mt-1 flex items-start gap-1 text-xs text-destructive", className)}
+      {...props}
+    >
+      <CircleAlert className="mt-px h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+      <span>{message}</span>
+    </p>
+  );
+}

--- a/lib/actions/create/createPool.ts
+++ b/lib/actions/create/createPool.ts
@@ -9,7 +9,9 @@ import { redirect } from "next/navigation";
 import { v4 as uuidv4 } from "uuid";
 
 export type CreatePoolState = {
+  /** Form-level message, shown in the error summary and as a toast. */
   message: string | null;
+  /** Per-field errors, rendered inline under each field. */
   errors?: Record<string, string[]>;
 };
 
@@ -17,8 +19,8 @@ export async function createPool(
   prevState: CreatePoolState,
   formData: FormData
 ): Promise<CreatePoolState> {
-  const baby_name = formData.get("baby_name") as string;
-  const organized_by = formData.get("organized_by") as string;
+  const baby_name = (formData.get("baby_name") as string | null)?.trim();
+  const organized_by = (formData.get("organized_by") as string | null)?.trim();
   const due_date = formData.get("due_date") as string;
   const slug = formData.get("slug") as string;
   const price_floor = parseFloat(formData.get("price_floor") as string);
@@ -29,97 +31,15 @@ export async function createPool(
     formData.get("mu_weight_ounces") as string,
     10
   );
-  const description = formData.get("description") as string | null;
+  const description = (formData.get("description") as string | null)?.trim();
   const video_url_raw = (formData.get("video_url") as string | null)?.trim();
-  // Optional external video — validated server-side; we only persist URLs we
-  // can convert into a YouTube/Vimeo embed, never arbitrary iframe sources.
-  let video_url: string | null = null;
-  if (video_url_raw) {
-    if (getVideoEmbed(video_url_raw)) {
-      video_url = video_url_raw;
-    } else {
-      return {
-        message:
-          "We couldn't recognize that video link. Please paste a YouTube or Vimeo URL (e.g. https://www.youtube.com/watch?v=...), or leave the field blank.",
-        errors: { video_url: ["Unrecognized video URL"] },
-      };
-    }
-  }
   const imageFile = formData.get("image") as File | null;
   const organizerImageFile = formData.get("organizer_image") as File | null;
+
   const supabase = await createClient();
 
-  let image_url: string | null = null;
-  if (imageFile && imageFile.size > 0) {
-    // Check file size (400kB limit)
-    const maxSize = 400 * 1024; // 400kB in bytes
-    if (imageFile.size > maxSize) {
-      return {
-        message:
-          "Image file size must be under 400kB. Please choose a smaller image or compress it.",
-        errors: {},
-      };
-    }
-
-    // Upload image to Supabase Storage
-    const fileExt = imageFile.name.split(".").pop();
-    const fileName = `${slug}-${uuidv4()}.${fileExt}`;
-    const { error: uploadError } = await supabase.storage
-      .from("pool-images")
-      .upload(fileName, imageFile, {
-        cacheControl: "3600",
-        upsert: false,
-        contentType: imageFile.type,
-      });
-    if (uploadError) {
-      return {
-        message: `Image upload failed: ${uploadError.message}`,
-        errors: {},
-      };
-    }
-    // Get public URL
-    const { data: publicUrlData } = supabase.storage
-      .from("pool-images")
-      .getPublicUrl(fileName);
-    image_url = publicUrlData?.publicUrl || null;
-  }
-
-  let organizer_image_url: string | null = null;
-  if (organizerImageFile && organizerImageFile.size > 0) {
-    // Check file size (400kB limit)
-    const maxSize = 400 * 1024; // 400kB in bytes
-    if (organizerImageFile.size > maxSize) {
-      return {
-        message:
-          "Organizer image file size must be under 400kB. Please choose a smaller image or compress it.",
-        errors: {},
-      };
-    }
-
-    // Upload organizer image to Supabase Storage
-    const fileExt = organizerImageFile.name.split(".").pop();
-    const fileName = `${slug}-organizer-${uuidv4()}.${fileExt}`;
-    const { error: uploadError } = await supabase.storage
-      .from("pool-images")
-      .upload(fileName, organizerImageFile, {
-        cacheControl: "3600",
-        upsert: false,
-        contentType: organizerImageFile.type,
-      });
-    if (uploadError) {
-      return {
-        message: `Organizer image upload failed: ${uploadError.message}`,
-        errors: {},
-      };
-    }
-    // Get public URL
-    const { data: publicUrlData } = supabase.storage
-      .from("pool-images")
-      .getPublicUrl(fileName);
-    organizer_image_url = publicUrlData?.publicUrl || null;
-  }
-
-  // Get user_id from Supabase session
+  // Auth check comes first — an unauthenticated request should fail before
+  // we do any work (like uploading images to storage).
   const {
     data: { user },
     error: userError,
@@ -133,38 +53,122 @@ export async function createPool(
   }
   const user_id = user.id;
 
-  if (!baby_name || !organized_by || !due_date || !slug) {
-    return {
-      message: "All required fields must be filled.",
-      errors: {},
-    };
-  }
+  // --- Validation ---
+  // Collect per-field errors so the client can render them inline next to
+  // each field (the same slots the client-side validation uses).
+  const errors: Record<string, string[]> = {};
 
-  // Validate pricing (only if price_floor and price_ceiling are provided)
-  // Remove requirement for sigma_days (pricing style)
-  if (!price_floor || !price_ceiling) {
-    return {
-      message: "Price floor and price ceiling are required.",
-      errors: {},
-    };
-  }
+  if (!baby_name) errors.baby_name = ["Enter the baby's name."];
+  if (!organized_by)
+    errors.organized_by = ["Enter who is organizing this pool."];
+  if (!due_date) errors.due_date = ["Select the expected due date."];
+  if (!slug) errors.slug = ["Enter a pool slug."];
+  if (!description)
+    errors.description = ["Write a short description of the pool."];
+  else if (description.length > 1000)
+    errors.description = ["Description must be 1000 characters or fewer."];
 
-  if (price_floor >= price_ceiling) {
-    return {
-      message: "Maximum price must be greater than minimum price.",
-      errors: {},
-    };
-  }
-
+  if (!Number.isFinite(price_floor))
+    errors.price_floor = ["Enter a minimum guess price."];
+  if (!Number.isFinite(price_ceiling))
+    errors.price_ceiling = ["Enter a maximum guess price."];
   if (
-    price_floor < MIN_PRICE_FLOOR ||
-    price_ceiling > MAX_PRICE_CEILING ||
-    price_ceiling < 1
-  ) {
+    Number.isFinite(price_floor) &&
+    Number.isFinite(price_ceiling) &&
+    price_floor >= price_ceiling
+  )
+    errors.price_ceiling = ["Maximum price must be greater than minimum price."];
+  if (
+    (Number.isFinite(price_floor) && price_floor < MIN_PRICE_FLOOR) ||
+    (Number.isFinite(price_ceiling) &&
+      (price_ceiling > MAX_PRICE_CEILING || price_ceiling < 1))
+  )
+    errors.price_ceiling = [
+      `Guess prices must be between $${MIN_PRICE_FLOOR} and $${MAX_PRICE_CEILING}.`,
+    ];
+
+  // Optional external video — validated server-side; we only persist URLs we
+  // can convert into a YouTube/Vimeo embed, never arbitrary iframe sources.
+  let video_url: string | null = null;
+  if (video_url_raw) {
+    if (getVideoEmbed(video_url_raw)) {
+      video_url = video_url_raw;
+    } else {
+      errors.video_url = [
+        "Unrecognized video link. Paste a YouTube or Vimeo URL (e.g. https://www.youtube.com/watch?v=...), or leave the field blank.",
+      ];
+    }
+  }
+
+  const maxImageSize = 400 * 1024; // 400kB in bytes
+  if (imageFile && imageFile.size > maxImageSize)
+    errors.image = [
+      "Image file size must be under 400kB. Please choose a smaller image or compress it.",
+    ];
+  if (organizerImageFile && organizerImageFile.size > maxImageSize)
+    errors.organizer_image = [
+      "Organizer image file size must be under 400kB. Please choose a smaller image or compress it.",
+    ];
+
+  if (Object.keys(errors).length > 0) {
     return {
-      message: `Guess prices must be between $${MIN_PRICE_FLOOR} and $${MAX_PRICE_CEILING}.`,
-      errors: {},
+      message: "Please fix the fields highlighted below.",
+      errors,
     };
+  }
+
+  let image_url: string | null = null;
+  if (imageFile && imageFile.size > 0) {
+    // Upload image to Supabase Storage
+    const fileExt = imageFile.name.split(".").pop();
+    const fileName = `${slug}-${uuidv4()}.${fileExt}`;
+    const { error: uploadError } = await supabase.storage
+      .from("pool-images")
+      .upload(fileName, imageFile, {
+        cacheControl: "3600",
+        upsert: false,
+        contentType: imageFile.type,
+      });
+    if (uploadError) {
+      return {
+        message: `Image upload failed: ${uploadError.message}`,
+        errors: { image: ["Image upload failed. Please try another image."] },
+      };
+    }
+    // Get public URL
+    const { data: publicUrlData } = supabase.storage
+      .from("pool-images")
+      .getPublicUrl(fileName);
+    image_url = publicUrlData?.publicUrl || null;
+  }
+
+  let organizer_image_url: string | null = null;
+  if (organizerImageFile && organizerImageFile.size > 0) {
+    // Upload organizer image to Supabase Storage
+    const fileExt = organizerImageFile.name.split(".").pop();
+    const fileName = `${slug}-organizer-${uuidv4()}.${fileExt}`;
+    const { error: uploadError } = await supabase.storage
+      .from("pool-images")
+      .upload(fileName, organizerImageFile, {
+        cacheControl: "3600",
+        upsert: false,
+        contentType: organizerImageFile.type,
+      });
+    if (uploadError) {
+      return {
+        message: `Organizer image upload failed: ${uploadError.message}`,
+        errors: {
+          organizer_image: [
+            "Organizer image upload failed. Please try another image.",
+          ],
+        },
+      };
+    }
+    // Get public URL
+    const { data: publicUrlData } = supabase.storage
+      .from("pool-images")
+      .getPublicUrl(fileName);
+    organizer_image_url = publicUrlData?.publicUrl || null;
   }
 
   // Set sigma values based on pricingModel
@@ -213,6 +217,15 @@ export async function createPool(
     .single();
 
   if (error) {
+    // 23505 = unique_violation. The slug is re-checked by the client just
+    // before submit, so hitting this means someone else claimed it in the
+    // meantime — report it on the slug field rather than as a raw DB error.
+    if (error.code === "23505") {
+      return {
+        message: "That pool URL was just taken. Please choose another.",
+        errors: { slug: ["This slug was just taken. Please choose another."] },
+      };
+    }
     return {
       message: error.message,
       errors: {},


### PR DESCRIPTION
Reworks /baby/create so users always know which fields need attention.

**Client**
- Required fields marked with * + legend; optional fields get "(optional)"
- Submit stays enabled while editing; clicking validates and shows a GOV.UK-style error summary (focus moved to it) with links to each field
- "Reward early, punish late" inline validation (validate on blur, re-validate on change once erroring)
- Errors = icon + destructive text + border, aria-invalid / aria-describedby wired
- Slug async available/taken states + suggestions; price max>min cross-field rule inline

**Server (createPool)**
- Returns per-field errors rendered in the same inline slots; input preserved
- Auth check runs before image uploads
- Duplicate-slug race (23505) maps to a friendly slug-field error

Adds components/ui/form-field.tsx (RequiredMark/OptionalMark/FieldError) using existing shadcn tokens.

Verified end-to-end in browser; tsc/eslint/vitest (42) all pass.