### PR TITLE
Tighten expected-weight / due-date row design

### DIFF
--- a/components/ui/baby/create-form.tsx
+++ b/components/ui/baby/create-form.tsx
@@ -85,6 +85,15 @@ export function CreateBabyPoolForm() {
   const [sexGuess, setSexGuess] = useState<BabySexGuess | null>(null);
   const [muDate] = useState(0); // 0 deviation from due date (in days)
 
+  // Editing the lbs/oz inputs by hand deselects the preset pill if the value
+  // no longer matches it, so the pills always reflect the actual weight.
+  const setWeight = (weight: number) => {
+    setMuWeight(weight);
+    setSexGuess((prev) =>
+      prev && Math.abs(SEX_WEIGHT_PRESETS[prev] - weight) < 1e-9 ? prev : null
+    );
+  };
+
   // Slug validation
   const [slugAvailable, setSlugAvailable] = useState<null | boolean>(null);
   const [slugChecking, setSlugChecking] = useState(false);
@@ -1038,7 +1047,7 @@ export function CreateBabyPoolForm() {
                           0,
                           Math.min(20, Number(e.target.value))
                         );
-                        setMuWeight(lbs + (muWeight % 1));
+                        setWeight(lbs + (muWeight % 1));
                       }}
                       className="rounded w-20 px-3 text-center"
                       required
@@ -1058,7 +1067,7 @@ export function CreateBabyPoolForm() {
                           0,
                           Math.min(15, Number(e.target.value))
                         );
-                        setMuWeight(Math.floor(muWeight) + oz / 16);
+                        setWeight(Math.floor(muWeight) + oz / 16);
                       }}
                       className="rounded w-20 px-3 text-center"
                       required

--- a/components/ui/baby/weight-sex-selector.tsx
+++ b/components/ui/baby/weight-sex-selector.tsx
@@ -26,7 +26,11 @@ export function WeightSexSelector({
   className?: string;
 }) {
   return (
-    <div className={clsx("flex gap-2", className)} role="radiogroup" aria-label="Baby's sex (sets average weight)">
+    <div
+      className={clsx("flex flex-wrap gap-2", className)}
+      role="radiogroup"
+      aria-label="Baby's sex (sets average weight)"
+    >
       {OPTIONS.map((opt) => {
         const selected = value === opt.value;
         return (
@@ -37,16 +41,16 @@ export function WeightSexSelector({
             aria-checked={selected}
             onClick={() => onChange(opt.value)}
             className={clsx(
-              "flex-1 rounded-full border px-3 py-2 text-sm font-medium transition-colors",
+              "inline-flex h-9 items-baseline gap-1.5 rounded-full border px-3.5 text-sm font-medium transition-colors",
               selected
                 ? "border-[#FF8C7A] bg-[#FF8C7A]/10 text-foreground"
                 : "border-input bg-background text-muted-foreground hover:border-[#FF8C7A]/60 hover:text-foreground"
             )}
           >
-            <span className="block leading-tight">{opt.label}</span>
+            <span className="leading-none">{opt.label}</span>
             <span
               className={clsx(
-                "block text-xs leading-tight",
+                "text-xs leading-none",
                 selected ? "text-[#e07363]" : "text-muted-foreground"
               )}
             >


### PR DESCRIPTION
- Compact the sex-selector pills (single-line label+hint, natural width) so they match the form's h-9 control scale
- Both columns now follow label → description → control, aligning the date picker and weight controls
- Editing lbs/oz by hand deselects the preset pill when the value no longer matches, keeping pills in sync with the actual weight