### PR TITLE
Clarify Stripe onboarding + say "global averages" for baby weight

### DIFF
--- a/app/api/stripe/connect/route.ts
+++ b/app/api/stripe/connect/route.ts
@@ -66,6 +66,12 @@ export async function POST(req: NextRequest) {
 
       const account = await stripe.accounts.create({
         type: "express",
+        // Pre-fill the organizer's email so Stripe's hosted onboarding skips
+        // the bare "Sign in to Express" prompt and binds onboarding to this
+        // email/account from the start. This also avoids a fork where a user
+        // with a *different* pre-existing Stripe account completes onboarding
+        // under that account while we've stored this new account's id.
+        email: user.email ?? undefined,
         capabilities: {
           card_payments: { requested: true },
           transfers: { requested: true },

--- a/app/baby/[slug]/connect/connect-stripe-client.tsx
+++ b/app/baby/[slug]/connect/connect-stripe-client.tsx
@@ -108,12 +108,16 @@ export default function ConnectStripeClient({
         <div className="space-y-3 text-sm text-muted-foreground">
           <p>
             To collect the money from <strong>{babyName}</strong>&apos;s pool,
-            you need to connect a Stripe account. This takes about 2 minutes.
+            you&apos;ll set up how you get paid with Stripe, our secure payment
+            partner. It takes about 2 minutes.
           </p>
           <ul className="list-disc list-inside space-y-1">
             <li>Payments go <strong>directly to you</strong> — not through us</li>
             <li>Stripe handles all payment processing securely</li>
-            <li>You can use an existing Stripe account or create a new one</li>
+            <li>
+              <strong>No Stripe account yet?</strong> Just enter your email on
+              the next screen to create one as you go
+            </li>
             {isTestMode && (
               <li>
                 In test mode, use SSN{" "}
@@ -122,6 +126,14 @@ export default function ConnectStripeClient({
               </li>
             )}
           </ul>
+        </div>
+
+        <div className="rounded-lg border bg-muted/40 p-3 text-xs text-muted-foreground">
+          <strong className="text-foreground">Heads up:</strong> the next page
+          is Stripe&apos;s secure setup, and your email will be pre-filled. Its
+          heading may say “Sign in,” but if you don&apos;t have a Stripe account,
+          continuing from there creates one as you go — no separate sign-up
+          needed.
         </div>
 
         {error && (
@@ -138,9 +150,9 @@ export default function ConnectStripeClient({
           {loading ? (
             <><LoadingSpinner /> Connecting...</>
           ) : isIncomplete ? (
-            <><RefreshCw className="h-4 w-4 mr-2" /> Resume Stripe Onboarding</>
+            <><RefreshCw className="h-4 w-4 mr-2" /> Resume Stripe setup</>
           ) : (
-            <><ExternalLink className="h-4 w-4 mr-2" /> Connect with Stripe</>
+            <><ExternalLink className="h-4 w-4 mr-2" /> Set up payments with Stripe</>
           )}
         </Button>
 

--- a/components/ui/baby/create-form.tsx
+++ b/components/ui/baby/create-form.tsx
@@ -1021,7 +1021,7 @@ export function CreateBabyPoolForm() {
                   <RequiredMark />
                 </Label>
                 <p className="text-xs text-muted-foreground">
-                  US national averages, or enter your own.
+                  Global averages, or enter your own.
                 </p>
                 <div className="flex gap-4 items-center mt-2">
                   <div className="flex items-center gap-2">

--- a/components/ui/baby/weight-sex-selector.tsx
+++ b/components/ui/baby/weight-sex-selector.tsx
@@ -45,7 +45,7 @@ export function WeightSexSelector({
             type="button"
             role="radio"
             aria-checked={selected}
-            title={`${label} — pre-fills the US average of ${hint}`}
+            title={`${label} — pre-fills the global average of ${hint}`}
             onClick={() => onChange(optValue)}
             className={clsx(
               "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium transition-colors",


### PR DESCRIPTION
**Stripe Express onboarding clarity**
The hosted Express page greets new users with "Sign in to Express," confusing people without a Stripe account.
- Connect screen copy explains the next page is Stripe's setup, email is pre-filled, and continuing creates an account as you go (no separate sign-up). Button now reads "Set up payments with Stripe."
- Pre-fill organizer email on the Express account so onboarding binds to that email/account from the start.

**Copy tweak**
- Baby-weight helper + chip tooltips now say "global averages" instead of "US national averages" (keeps the code comment noting the CDC data source).