### PR TITLE
Lazy-instantiate Stripe client so CI builds without STRIPE_SECRET_KEY

### DIFF
--- a/app/admin/fees/page.tsx
+++ b/app/admin/fees/page.tsx
@@ -1,6 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect, notFound } from "next/navigation";
-import Stripe from "stripe";
+import { getStripe } from "@/lib/stripe";
 import {
   Table,
   TableBody,
@@ -11,8 +11,6 @@ import {
 } from "@/components/ui/table";
 
 export const metadata = { title: "Platform Fees - Admin" };
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
 type FeeRow = {
   id: string;
@@ -25,6 +23,7 @@ type FeeRow = {
 };
 
 async function getFees(): Promise<FeeRow[]> {
+  const stripe = getStripe();
   const fees = await stripe.applicationFees.list({ limit: 50 });
   return Promise.all(
     fees.data.map(async (fee) => {

--- a/lib/actions/admin/deletePool.ts
+++ b/lib/actions/admin/deletePool.ts
@@ -1,11 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import Stripe from "stripe";
+import { getStripe } from "@/lib/stripe";
 import { requireAdmin } from "@/lib/admin/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
 export type AdminDeletePoolResult = {
   error?: string;
@@ -59,7 +57,7 @@ export async function adminDeletePool(
   const failures: string[] = [];
   for (const guess of paid) {
     try {
-      await stripe.refunds.create({
+      await getStripe().refunds.create({
         payment_intent: guess.payment_id!,
         refund_application_fee: true,
       });

--- a/lib/actions/admin/deleteUser.ts
+++ b/lib/actions/admin/deleteUser.ts
@@ -1,11 +1,9 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import Stripe from "stripe";
+import { getStripe } from "@/lib/stripe";
 import { requireAdmin } from "@/lib/admin/auth";
 import { createAdminClient } from "@/lib/supabase/admin";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
 export type AdminDeleteUserResult = {
   error?: string;
@@ -86,7 +84,7 @@ export async function adminDeleteUser(
   const failures: string[] = [];
   for (const guess of paid) {
     try {
-      await stripe.refunds.create({
+      await getStripe().refunds.create({
         payment_intent: guess.payment_id!,
         refund_application_fee: true,
       });

--- a/lib/actions/baby/createCheckoutSession.ts
+++ b/lib/actions/baby/createCheckoutSession.ts
@@ -2,9 +2,7 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { PLATFORM_FEE_PERCENT } from "@/lib/constants";
-import Stripe from "stripe";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+import { getStripe } from "@/lib/stripe";
 
 // Helper function to get the base URL with proper protocol
 function getBaseUrl() {
@@ -89,7 +87,7 @@ export async function createCheckoutSession(
     const oz = Math.round(data.guessWeight % 16);
     const formattedWeight = `${lbs} lbs ${oz} oz`;
 
-    const session = await stripe.checkout.sessions.create({
+    const session = await getStripe().checkout.sessions.create({
       payment_method_types: ["card"],
       line_items: [
         {

--- a/lib/actions/baby/refundGuess.ts
+++ b/lib/actions/baby/refundGuess.ts
@@ -2,9 +2,8 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
+import { getStripe } from "@/lib/stripe";
 import Stripe from "stripe";
-
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
 export type RefundGuessState = {
   error?: string;
@@ -62,7 +61,7 @@ export async function refundGuess(
   }
 
   try {
-    await stripe.refunds.create({
+    await getStripe().refunds.create({
       payment_intent: guess.payment_id,
       // Return the platform's application fee as well, so the guesser is
       // refunded 100% of their donation. The platform eats Stripe's

--- a/lib/stripe.ts
+++ b/lib/stripe.ts
@@ -1,0 +1,18 @@
+import Stripe from "stripe";
+
+// Lazily instantiated so `next build` can collect page data in environments
+// (e.g. CI) where STRIPE_SECRET_KEY is not set. Constructing a Stripe client
+// at module scope throws "Neither apiKey nor config.authenticator provided"
+// during static analysis of any page that imports it.
+let stripe: Stripe | null = null;
+
+export function getStripe(): Stripe {
+  if (!stripe) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) {
+      throw new Error("STRIPE_SECRET_KEY is not set");
+    }
+    stripe = new Stripe(key);
+  }
+  return stripe;
+}


### PR DESCRIPTION
The `build-and-test` check has failed on main since the Stripe Connect launch work: `next build` throws `Neither apiKey nor config.authenticator provided` while collecting page data for `/admin/fees`, because CI has no `STRIPE_SECRET_KEY` and several modules construct `new Stripe(...)` at module scope.

**Fix:** new `lib/stripe.ts` exports a memoized `getStripe()`; the five module-scope instantiations (admin fees page, checkout session, refund guess, admin delete pool/user) now call it inside their handlers. Route handlers already built the client per-request and are unchanged.

**Verified locally:** `env -u STRIPE_SECRET_KEY npm run build` succeeds; `/admin/fees` builds as a dynamic page; `tsc --noEmit` and all 42 unit tests pass.