### PR TITLE
Donor-pays fee model: creators keep 100%

### DIFF
--- a/app/baby/[slug]/refund-cell.tsx
+++ b/app/baby/[slug]/refund-cell.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { Tables } from "@/database.types";
 import { refundGuess } from "@/lib/actions/baby/refundGuess";
+import { getTotalCents } from "@/lib/constants";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,6 +34,9 @@ export function RefundCell({ guess }: { guess: Tables<"guesses"> }) {
   }
 
   const price = Number(guess.calculated_price ?? 0);
+  // Donors were charged the guess plus the platform fee on top, so a full
+  // refund returns that larger amount.
+  const chargeTotal = getTotalCents(Math.round(price * 100)) / 100;
   const name = guess.is_anonymous ? "Anonymous" : guess.name || "Anonymous";
 
   const handleRefund = () => {
@@ -60,7 +64,10 @@ export function RefundCell({ guess }: { guess: Tables<"guesses"> }) {
           <AlertDialogTitle>Issue a refund?</AlertDialogTitle>
           <AlertDialogDescription>
             This will refund{" "}
-            <strong className="text-foreground">${price.toFixed(2)}</strong> to{" "}
+            <strong className="text-foreground">
+              ${chargeTotal.toFixed(2)}
+            </strong>{" "}
+            (the ${price.toFixed(2)} guess plus platform fee) to{" "}
             <strong className="text-foreground">{name}</strong>&apos;s card.
             This action is <strong>irreversible</strong> — the money goes back
             immediately and cannot be reclaimed.
@@ -80,7 +87,7 @@ export function RefundCell({ guess }: { guess: Tables<"guesses"> }) {
                 <LoadingSpinner /> Refunding...
               </>
             ) : (
-              `Yes, refund $${price.toFixed(2)}`
+              `Yes, refund $${chargeTotal.toFixed(2)}`
             )}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/components/blocks/faq.tsx
+++ b/components/blocks/faq.tsx
@@ -6,7 +6,6 @@ import {
   PLATFORM_FEE_PERCENT,
 } from "@/lib/constants";
 
-const CREATOR_KEEP_PERCENT = Math.round((1 - PLATFORM_FEE_PERCENT) * 100);
 const PLATFORM_PERCENT = Math.round(PLATFORM_FEE_PERCENT * 100);
 
 type Faq = { q: string; a: React.ReactNode };
@@ -36,15 +35,15 @@ const faqs: Faq[] = [
     a: (
       <>
         <p>
-          Creating a pool is free. Guessers pay the price shown on the sliders
-          — and that&apos;s exactly what they pay, nothing added on top.
+          Creating a pool is free, and{" "}
+          <strong>creators keep 100% of every guess</strong> — the full amount
+          on the slider goes to the family.
         </p>
         <p>
-          Creators keep exactly {CREATOR_KEEP_PERCENT}% of every guess —
-          that&apos;s a flat rate with no other deductions. We take a{" "}
-          {PLATFORM_PERCENT}% platform fee and cover the card processing costs
-          out of our share. Example: on a $45 guess, the creator receives
-          exactly $40.50.
+          Guessers pay a {PLATFORM_PERCENT}% platform + Stripe processing fee
+          on top of their guess, shown as its own line at checkout. Example: a
+          $45.00 guess charges the guesser $50.00 total; the family receives
+          the full $45.00.
         </p>
       </>
     ),

--- a/components/ui/baby/BabyPoolClient.tsx
+++ b/components/ui/baby/BabyPoolClient.tsx
@@ -12,6 +12,7 @@ import {
   ownerGuessColumns,
 } from "@/app/baby/[slug]/columns";
 import { getGuessPrice } from "@/lib/helpers/pricing";
+import { getFeeCents, getTotalCents } from "@/lib/constants";
 import { loadStripe } from "@stripe/stripe-js";
 import { toast } from "sonner";
 import { AlertCircle, ExternalLink, Pencil } from "lucide-react";
@@ -206,6 +207,9 @@ export function BabyPoolClient({
     // For pricing, use ounces directly
     weightGuess: weightGuessOunces,
   });
+  const guessCents = Math.round(totalPrice * 100);
+  const feeDisplay = getFeeCents(guessCents) / 100;
+  const checkoutTotalDisplay = getTotalCents(guessCents) / 100;
 
   // Owners see every guess (including refunded ones, labeled); guests only
   // see active (paid) guesses — a refunded donation isn't a donation.
@@ -428,6 +432,15 @@ export function BabyPoolClient({
                         <span>{`$${weightPrice.toFixed(2)}`}</span>
                       </div>
                     </div>
+                    <p className="text-xs text-muted-foreground mt-4 border-t pt-3">
+                      At checkout you&apos;ll pay{" "}
+                      <strong className="text-foreground">
+                        ${checkoutTotalDisplay.toFixed(2)}
+                      </strong>{" "}
+                      — your guess plus a ${feeDisplay.toFixed(2)} platform +
+                      processing fee (10%). The family receives 100% of your
+                      guess.
+                    </p>
                   </CardContent>
                 </Card>
               </div>

--- a/lib/actions/baby/createCheckoutSession.ts
+++ b/lib/actions/baby/createCheckoutSession.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
-import { PLATFORM_FEE_PERCENT } from "@/lib/constants";
+import { getFeeCents } from "@/lib/constants";
 import { getStripe } from "@/lib/stripe";
 
 // Helper function to get the base URL with proper protocol
@@ -87,6 +87,11 @@ export async function createCheckoutSession(
     const oz = Math.round(data.guessWeight % 16);
     const formattedWeight = `${lbs} lbs ${oz} oz`;
 
+    // Donor-pays-fee model: the guess price goes to the creator in full;
+    // the fee is added on top and shown as its own line item at checkout.
+    const guessCents = Math.round(data.price * 100);
+    const feeCents = getFeeCents(guessCents);
+
     const session = await getStripe().checkout.sessions.create({
       payment_method_types: ["card"],
       line_items: [
@@ -97,7 +102,17 @@ export async function createCheckoutSession(
               name: `Guess on ${data.babyName}`,
               description: `Your guess: ${formattedDate} at ${formattedWeight}`,
             },
-            unit_amount: Math.round(data.price * 100),
+            unit_amount: guessCents,
+          },
+          quantity: 1,
+        },
+        {
+          price_data: {
+            currency: "usd",
+            product_data: {
+              name: "bellcurve.baby platform + Stripe processing fee (10%)",
+            },
+            unit_amount: feeCents,
           },
           quantity: 1,
         },
@@ -105,14 +120,12 @@ export async function createCheckoutSession(
       mode: "payment",
       success_url: `${getBaseUrl()}/baby/${data.slug}?payment=success`,
       cancel_url: `${getBaseUrl()}/baby/${data.slug}?payment=cancelled`,
-      // Route funds directly to the pool creator's connected Stripe account,
-      // keeping the platform fee (creator takes home 90% of each guess).
+      // The creator receives exactly the guess price (100%); the platform
+      // keeps the fee line item to cover Stripe processing + our cut.
       payment_intent_data: {
-        application_fee_amount: Math.round(
-          data.price * 100 * PLATFORM_FEE_PERCENT
-        ),
         transfer_data: {
           destination: pool.stripe_account_id,
+          amount: guessCents,
         },
       },
       metadata: {

--- a/lib/actions/baby/refundGuess.ts
+++ b/lib/actions/baby/refundGuess.ts
@@ -61,13 +61,13 @@ export async function refundGuess(
   }
 
   try {
+    // Refunds the full charge (guess + fee), so the donor is made 100%
+    // whole. The platform eats Stripe's processing fee on refunds — that's
+    // our cost of doing business, not the guesser's or creator's problem.
+    // (No application_fee reversal needed: in the donor-pays-fee model the
+    // platform never took an application_fee_amount.)
     await getStripe().refunds.create({
       payment_intent: guess.payment_id,
-      // Return the platform's application fee as well, so the guesser is
-      // refunded 100% of their donation. The platform eats Stripe's
-      // processing fee on refunds — that's our cost of doing business,
-      // not the guesser's or creator's problem.
-      refund_application_fee: true,
     });
     // The charge.refunded webhook flips payment_status to 'refunded'
     // (usually within a second). Revalidate so the table updates.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -13,3 +13,20 @@ export const MIN_PRICE_FLOOR = 10; // creators cannot set a floor below this
 export const MAX_PRICE_CEILING = 200; // ...nor a ceiling above this
 export const DEFAULT_PRICE_FLOOR = 15;
 export const DEFAULT_PRICE_CEILING = 60;
+
+/**
+ * Donor-pays-fee model: the donor is charged the guess price plus a fee on
+ * top, so the pool creator receives 100% of their guess. The fee line shown
+ * at checkout is PLATFORM_FEE_PERCENT of the TOTAL charge, so it must be
+ * computed from the guess price as p/(1-r) - p (equivalently total = p/(1-r)).
+ *
+ * Example ($100 guess, 10%): total = $111.11, fee = $11.11 (= 10% of total),
+ * Stripe processing ($3.52) comes out of the fee; platform nets the rest.
+ */
+export function getFeeCents(guessCents: number): number {
+  return Math.round(guessCents / (1 - PLATFORM_FEE_PERCENT)) - guessCents;
+}
+
+export function getTotalCents(guessCents: number): number {
+  return guessCents + getFeeCents(guessCents);
+}

--- a/tests/fees.test.ts
+++ b/tests/fees.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import {
+  getFeeCents,
+  getTotalCents,
+  PLATFORM_FEE_PERCENT,
+} from "../lib/constants";
+
+describe("donor-pays fee math", () => {
+  it("adds the fee on top so the creator receives 100% of the guess", () => {
+    // $100 guess: donor pays $111.11, creator gets $100.00
+    expect(getFeeCents(10000)).toBe(1111);
+    expect(getTotalCents(10000)).toBe(11111);
+  });
+
+  it("the fee line is exactly PLATFORM_FEE_PERCENT of the total charge", () => {
+    for (const guessCents of [1000, 1500, 4267, 4500, 10000, 20000]) {
+      const fee = getFeeCents(guessCents);
+      const total = guessCents + fee;
+      // fee should be ~10% of total (within a rounding cent)
+      expect(Math.abs(fee - total * PLATFORM_FEE_PERCENT)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("round-trips: total minus fee equals the guess", () => {
+    for (const guessCents of [1000, 1710, 3333, 9999]) {
+      expect(getTotalCents(guessCents) - getFeeCents(guessCents)).toBe(
+        guessCents
+      );
+    }
+  });
+
+  it("fee is always positive and monotonic in the guess price", () => {
+    let prev = 0;
+    for (const guessCents of [1000, 2000, 5000, 10000, 50000]) {
+      const fee = getFeeCents(guessCents);
+      expect(fee).toBeGreaterThan(prev);
+      prev = fee;
+    }
+  });
+
+  it("platform nets the fee minus Stripe processing (2.9% + 30c of total)", () => {
+    const guessCents = 10000;
+    const total = getTotalCents(guessCents);
+    const fee = getFeeCents(guessCents);
+    const stripeProcessing = Math.round(total * 0.029) + 30;
+    const platformNet = fee - stripeProcessing;
+    // On a $100 guess the platform should net roughly $7.59
+    expect(platformNet).toBeGreaterThan(700);
+    expect(platformNet).toBeLessThan(800);
+  });
+});


### PR DESCRIPTION
Flips the fee from creator-side (application_fee_amount, creator got 90%) to donor-side (itemized fee line at checkout, creator gets 100% of the guess).

**Checkout itemization:**
- Guess on <baby> — $X.XX (to the family)
- bellcurve.baby platform + Stripe processing fee (10%) — $Y.YY

Fee is 10% of the total charge (so the label is truthful): $100 guess → $111.11 total, creator gets $100.00, Stripe takes $3.52, platform nets $7.59.

Test plan: verified fee math via unit tests; end-to-end checkout test on dev with test keys before merge.