### PR TITLE
Additive fee math + full refund flags

### DIFF
--- a/components/blocks/faq.tsx
+++ b/components/blocks/faq.tsx
@@ -42,7 +42,7 @@ const faqs: Faq[] = [
         <p>
           Guessers pay a {PLATFORM_PERCENT}% platform + Stripe processing fee
           on top of their guess, shown as its own line at checkout. Example: a
-          $45.00 guess charges the guesser $50.00 total; the family receives
+          $45.00 guess charges the guesser $49.50 total; the family receives
           the full $45.00.
         </p>
       </>

--- a/lib/actions/baby/refundGuess.ts
+++ b/lib/actions/baby/refundGuess.ts
@@ -61,13 +61,15 @@ export async function refundGuess(
   }
 
   try {
-    // Refunds the full charge (guess + fee), so the donor is made 100%
-    // whole. The platform eats Stripe's processing fee on refunds — that's
-    // our cost of doing business, not the guesser's or creator's problem.
-    // (No application_fee reversal needed: in the donor-pays-fee model the
-    // platform never took an application_fee_amount.)
+    // Full refund: donor gets back 100% of the total charge (guess + fee).
+    // reverse_transfer claws the base donation back from the creator's
+    // connected account; refund_application_fee returns any platform fee
+    // retained on the charge. The platform absorbs the original,
+    // non-refundable Stripe processing fee as an operational loss.
     await getStripe().refunds.create({
       payment_intent: guess.payment_id,
+      reverse_transfer: true,
+      refund_application_fee: true,
     });
     // The charge.refunded webhook flips payment_status to 'refunded'
     // (usually within a second). Revalidate so the table updates.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -15,16 +15,16 @@ export const DEFAULT_PRICE_FLOOR = 15;
 export const DEFAULT_PRICE_CEILING = 60;
 
 /**
- * Donor-pays-fee model: the donor is charged the guess price plus a fee on
- * top, so the pool creator receives 100% of their guess. The fee line shown
- * at checkout is PLATFORM_FEE_PERCENT of the TOTAL charge, so it must be
- * computed from the guess price as p/(1-r) - p (equivalently total = p/(1-r)).
+ * Donor-pays-fee model: the donor is charged the guess price plus a simple,
+ * additive 10% surcharge on top, so the pool creator receives 100% of the
+ * guess. No margin math — the fee is calculated directly on the base amount.
  *
- * Example ($100 guess, 10%): total = $111.11, fee = $11.11 (= 10% of total),
- * Stripe processing ($3.52) comes out of the fee; platform nets the rest.
+ * Example ($100 guess, 10%): fee = $10.00, total = $110.00. Stripe
+ * processing (2.9% + 30c of the total) comes out of the fee; the platform
+ * nets the rest ($6.51 in the example).
  */
 export function getFeeCents(guessCents: number): number {
-  return Math.round(guessCents / (1 - PLATFORM_FEE_PERCENT)) - guessCents;
+  return Math.round(guessCents * PLATFORM_FEE_PERCENT);
 }
 
 export function getTotalCents(guessCents: number): number {

--- a/tests/fees.test.ts
+++ b/tests/fees.test.ts
@@ -5,28 +5,36 @@ import {
   PLATFORM_FEE_PERCENT,
 } from "../lib/constants";
 
-describe("donor-pays fee math", () => {
-  it("adds the fee on top so the creator receives 100% of the guess", () => {
-    // $100 guess: donor pays $111.11, creator gets $100.00
-    expect(getFeeCents(10000)).toBe(1111);
-    expect(getTotalCents(10000)).toBe(11111);
+describe("donor-pays fee math (additive surcharge)", () => {
+  it("adds an additive 10% surcharge on top of the base donation", () => {
+    // $100 base: fee = $10.00, total = $110.00
+    expect(getFeeCents(10000)).toBe(1000);
+    expect(getTotalCents(10000)).toBe(11000);
   });
 
-  it("the fee line is exactly PLATFORM_FEE_PERCENT of the total charge", () => {
+  it("the fee is exactly PLATFORM_FEE_PERCENT of the BASE donation", () => {
     for (const guessCents of [1000, 1500, 4267, 4500, 10000, 20000]) {
       const fee = getFeeCents(guessCents);
-      const total = guessCents + fee;
-      // fee should be ~10% of total (within a rounding cent)
-      expect(Math.abs(fee - total * PLATFORM_FEE_PERCENT)).toBeLessThanOrEqual(1);
+      expect(fee).toBe(Math.round(guessCents * PLATFORM_FEE_PERCENT));
     }
   });
 
-  it("round-trips: total minus fee equals the guess", () => {
+  it("total charge = base + fee", () => {
     for (const guessCents of [1000, 1710, 3333, 9999]) {
-      expect(getTotalCents(guessCents) - getFeeCents(guessCents)).toBe(
-        guessCents
+      expect(getTotalCents(guessCents)).toBe(
+        guessCents + getFeeCents(guessCents)
       );
     }
+  });
+
+  it("platform nets fee minus Stripe processing (2.9% + 30c of gross)", () => {
+    // $100 example from the spec: Stripe takes $3.49, platform nets $6.51
+    const guessCents = 10000;
+    const total = getTotalCents(guessCents);
+    const fee = getFeeCents(guessCents);
+    const stripeFee = Math.round(total * 0.029) + 30;
+    expect(stripeFee).toBe(349);
+    expect(fee - stripeFee).toBe(651);
   });
 
   it("fee is always positive and monotonic in the guess price", () => {
@@ -36,16 +44,5 @@ describe("donor-pays fee math", () => {
       expect(fee).toBeGreaterThan(prev);
       prev = fee;
     }
-  });
-
-  it("platform nets the fee minus Stripe processing (2.9% + 30c of total)", () => {
-    const guessCents = 10000;
-    const total = getTotalCents(guessCents);
-    const fee = getFeeCents(guessCents);
-    const stripeProcessing = Math.round(total * 0.029) + 30;
-    const platformNet = fee - stripeProcessing;
-    // On a $100 guess the platform should net roughly $7.59
-    expect(platformNet).toBeGreaterThan(700);
-    expect(platformNet).toBeLessThan(800);
   });
 });


### PR DESCRIPTION
Implements the exact financial spec:

**Additive fee:** fee = base × 10% ($100 → $10 → $110 total). No margin division. Platform nets fee − Stripe processing = $6.51 on $100.

**Refunds:** reverse_transfer + refund_application_fee both set. Donor gets 100% of gross ($110), creator clawed back base ($100), platform absorbs Stripe processing (−$3.49).

Tests cover the spec's exact numbers.