### PR TITLE
Persist livemode on guesses; simplify /admin/fees

### DIFF
--- a/app/admin/fees/page.tsx
+++ b/app/admin/fees/page.tsx
@@ -1,7 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { redirect, notFound } from "next/navigation";
 import { getFeeCents } from "@/lib/constants";
-import { getStripe } from "@/lib/stripe";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -19,55 +18,18 @@ export const metadata = { title: "Platform Fees - Admin" };
 // item), so there is no Stripe application_fee object to list. The source of
 // truth for platform earnings is therefore our own guesses table.
 //
-// Dev and prod share one Supabase DB but use different Stripe keys (test vs
-// live), and Stripe payment ids share the pi_3... prefix, so the only way to
-// tell a sandbox payment from a real one is the charge's `livemode` flag.
-type GuessRow = {
+// Dev and prod share one Supabase DB but use different Stripe keys. Each
+// guess's `livemode` (recorded at webhook time) separates real (live) from
+// sandbox (test-mode) payments; NULL means it predates the column ("unknown").
+type FeeRow = {
   id: string;
   created_at: string | null;
   calculated_price: number; // dollars, the guess amount the creator received
   payment_status: string | null;
-  payment_id: string | null;
+  livemode: boolean | null;
   pool_id: string;
   pools: { slug: string } | null;
 };
-
-type FeeRow = GuessRow & {
-  /** true = real money, false = sandbox, null = couldn't determine. */
-  livemode: boolean | null;
-};
-
-// Resolve livemode per payment by looking at its Stripe charge. Batched with
-// a small concurrency cap so a large page doesn't hammer the Stripe API.
-async function withLivemode(rows: GuessRow[]): Promise<FeeRow[]> {
-  const stripe = getStripe();
-  const CONCURRENCY = 5;
-  const out: FeeRow[] = new Array(rows.length);
-  let i = 0;
-  async function worker() {
-    while (i < rows.length) {
-      const idx = i++;
-      const row = rows[idx];
-      let livemode: boolean | null = null;
-      if (row.payment_id) {
-        try {
-          const pi = await stripe.paymentIntents.retrieve(row.payment_id, {
-            expand: ["latest_charge"],
-          });
-          const charge = pi.latest_charge;
-          if (charge && typeof charge !== "string") {
-            livemode = charge.livemode;
-          }
-        } catch {
-          livemode = null;
-        }
-      }
-      out[idx] = { ...row, livemode };
-    }
-  }
-  await Promise.all(Array.from({ length: CONCURRENCY }, worker));
-  return out;
-}
 
 export default async function AdminFeesPage() {
   const supabase = await createClient();
@@ -91,20 +53,21 @@ export default async function AdminFeesPage() {
   const { data: rows, error } = await supabase
     .from("guesses")
     .select(
-      "id, created_at, calculated_price, payment_status, payment_id, pool_id, pools(slug)"
+      "id, created_at, calculated_price, payment_status, livemode, pool_id, pools(slug)"
     )
     .in("payment_status", ["paid", "refunded"])
     .order("created_at", { ascending: false })
-    .limit(100)
-    .returns<GuessRow[]>();
+    .limit(200)
+    .returns<FeeRow[]>();
 
   if (error) {
     console.error("Failed to load platform fees:", error);
   }
-  const fees = await withLivemode(rows ?? []);
+  const fees = rows ?? [];
 
   const isPaid = (f: FeeRow) => f.payment_status === "paid";
   const isLive = (f: FeeRow) => f.livemode === true;
+  const isTest = (f: FeeRow) => f.livemode === false;
   const guessCents = (f: FeeRow) => Math.round(f.calculated_price * 100);
   const feeCentsFor = (f: FeeRow) => getFeeCents(guessCents(f));
 
@@ -113,9 +76,11 @@ export default async function AdminFeesPage() {
   const liveFeeCents = liveFees.reduce((s, f) => s + feeCentsFor(f), 0);
   const liveGrossCents = liveFees.reduce((s, f) => s + guessCents(f), 0);
   // Sandbox totals, shown separately so they don't inflate the real numbers.
-  const testFees = fees.filter((f) => isPaid(f) && f.livemode === false);
+  const testFees = fees.filter((f) => isPaid(f) && isTest(f));
   const testFeeCents = testFees.reduce((s, f) => s + feeCentsFor(f), 0);
   const testGrossCents = testFees.reduce((s, f) => s + guessCents(f), 0);
+  // Pre-livemode rows (unknown) — call out if any need backfilling.
+  const unknownCount = fees.filter((f) => isPaid(f) && f.livemode === null).length;
 
   return (
     <div className="max-w-4xl mx-auto mt-10 px-4 py-12">
@@ -142,19 +107,27 @@ export default async function AdminFeesPage() {
         </div>
       </div>
 
-      {testFees.length > 0 && (
-        <p className="text-center text-xs text-muted-foreground mb-8">
-          Plus{" "}
-          <span className="font-medium">
-            ${(testFeeCents / 100).toFixed(2)}
-          </span>{" "}
-          in fees on{" "}
-          <span className="font-medium">
-            ${(testGrossCents / 100).toFixed(2)}
-          </span>{" "}
-          of sandbox (test-mode) guesses — not real money.
-        </p>
-      )}
+      <div className="text-center text-xs text-muted-foreground mb-8 space-y-1">
+        {testFees.length > 0 && (
+          <p>
+            Plus{" "}
+            <span className="font-medium">
+              ${(testFeeCents / 100).toFixed(2)}
+            </span>{" "}
+            in fees on{" "}
+            <span className="font-medium">
+              ${(testGrossCents / 100).toFixed(2)}
+            </span>{" "}
+            of sandbox (test-mode) guesses — not real money.
+          </p>
+        )}
+        {unknownCount > 0 && (
+          <p>
+            {unknownCount} older {unknownCount === 1 ? "guess" : "guesses"}{" "}
+            predate test/live tracking and are excluded from both totals.
+          </p>
+        )}
+      </div>
 
       {fees.length === 0 ? (
         <p className="text-center text-muted-foreground">
@@ -202,7 +175,7 @@ export default async function AdminFeesPage() {
                       ) : fee.livemode === false ? (
                         <Badge variant="secondary">Test</Badge>
                       ) : (
-                        <Badge variant="outline">—</Badge>
+                        <Badge variant="outline">Unknown</Badge>
                       )}
                     </TableCell>
                     <TableCell>

--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -30,7 +30,8 @@ async function createGuess(
   price: number,
   paymentIntentId: string,
   name: string | null,
-  isAnonymous: boolean
+  isAnonymous: boolean,
+  livemode: boolean | null
 ) {
   const supabase = getAnonClient();
 
@@ -45,6 +46,7 @@ async function createGuess(
     p_payment_id: paymentIntentId,
     p_name: name ?? "",
     p_is_anonymous: isAnonymous,
+    p_livemode: livemode,
   });
 
   if (error) {
@@ -187,7 +189,11 @@ export async function POST(req: NextRequest) {
         numericPrice,
         paymentIntentId,
         name || null,
-        isAnonymous
+        isAnonymous,
+        // The Stripe event carries livemode (true = real money, false =
+        // sandbox); record it so /admin/fees can separate test vs live
+        // without a Stripe lookup per row.
+        session.livemode ?? null
       );
 
       console.log(

--- a/database.types.ts
+++ b/database.types.ts
@@ -22,6 +22,7 @@ export type Database = {
           guessed_weight: number
           id: string
           is_anonymous: boolean
+          livemode: boolean | null
           name: string | null
           payment_id: string | null
           payment_status: string | null
@@ -35,6 +36,7 @@ export type Database = {
           guessed_weight: number
           id?: string
           is_anonymous?: boolean
+          livemode?: boolean | null
           name?: string | null
           payment_id?: string | null
           payment_status?: string | null
@@ -48,6 +50,7 @@ export type Database = {
           guessed_weight?: number
           id?: string
           is_anonymous?: boolean
+          livemode?: boolean | null
           name?: string | null
           payment_id?: string | null
           payment_status?: string | null
@@ -204,6 +207,7 @@ export type Database = {
           p_guessed_birth_date: string
           p_guessed_weight: number
           p_is_anonymous: boolean
+          p_livemode?: boolean | null
           p_name: string
           p_payment_id: string
           p_pool_id: string

--- a/supabase/migrations/008_guess_livemode.sql
+++ b/supabase/migrations/008_guess_livemode.sql
@@ -1,0 +1,76 @@
+-- Migration: record whether each paid guess was a real (live) or sandbox
+-- (test-mode) Stripe payment.
+--
+-- Dev and prod share this one Supabase DB but use different Stripe keys, and
+-- Stripe payment ids share the pi_3... prefix, so the only reliable way to
+-- tell them apart is the `livemode` flag present on the Stripe event/charge.
+-- Capturing it at webhook time lets /admin/fees filter in SQL instead of
+-- doing a Stripe API lookup per row.
+
+ALTER TABLE guesses
+  ADD COLUMN IF NOT EXISTS livemode boolean;
+
+-- Backfill note: rows created before this column existed have livemode = NULL
+-- ("unknown"). They can be backfilled from Stripe by payment_id; see the
+-- /admin/fees page, which treats NULL as "unknown" mode.
+
+-- Thread livemode through the guess-creation RPC so the webhook can record it.
+CREATE OR REPLACE FUNCTION create_guess_from_webhook(
+  p_pool_id        uuid,
+  p_user_id        uuid,
+  p_guessed_birth_date date,
+  p_guessed_weight numeric,
+  p_calculated_price numeric,
+  p_payment_id     text,
+  p_name           text,
+  p_is_anonymous   boolean,
+  p_livemode       boolean DEFAULT NULL
+)
+RETURNS json
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_pool   pools%ROWTYPE;
+  v_result guesses%ROWTYPE;
+BEGIN
+  -- Validate pool exists and is accepting guesses
+  SELECT * INTO v_pool FROM pools WHERE id = p_pool_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Pool not found: %', p_pool_id;
+  END IF;
+  IF v_pool.is_locked IS TRUE THEN
+    RAISE EXCEPTION 'Pool is locked: %', p_pool_id;
+  END IF;
+
+  -- Idempotency: return existing guess if this payment was already processed
+  SELECT * INTO v_result FROM guesses WHERE payment_id = p_payment_id;
+  IF FOUND THEN
+    RETURN row_to_json(v_result);
+  END IF;
+
+  -- Insert the verified guess
+  INSERT INTO guesses (
+    pool_id, user_id, guessed_birth_date, guessed_weight,
+    calculated_price, payment_id, payment_status, name, is_anonymous,
+    livemode
+  )
+  VALUES (
+    p_pool_id, p_user_id, p_guessed_birth_date, p_guessed_weight,
+    p_calculated_price, p_payment_id, 'paid', p_name, p_is_anonymous,
+    p_livemode
+  )
+  RETURNING * INTO v_result;
+
+  RETURN row_to_json(v_result);
+END;
+$$;
+
+-- Match the original migration's grants (anon/authenticated only).
+REVOKE ALL ON FUNCTION create_guess_from_webhook(
+  uuid, uuid, date, numeric, numeric, text, text, boolean, boolean
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION create_guess_from_webhook(
+  uuid, uuid, date, numeric, numeric, text, text, boolean, boolean
+) TO anon, authenticated;


### PR DESCRIPTION
Replaces per-row Stripe `livemode` lookups on /admin/fees with a `guesses.livemode` column recorded when the payment webhook fires.

- **Migration 008**: add `guesses.livemode` (NULL = pre-existing/"unknown") and thread `p_livemode` through `create_guess_from_webhook`
- **Webhook**: pass `session.livemode` into the RPC
- **/admin/fees**: read `livemode` from the DB (no Stripe round-trips); Live/Test/Unknown badge, live-only headline totals, sandbox + unknown noted separately
- `database.types.ts` updated to match

⚠️ **Deploy dependency**: run `supabase/migrations/008_guess_livemode.sql` in the Supabase SQL Editor before/with this deploy — the webhook and admin page expect the column to exist. After applying, optionally `npm run typegen` to confirm types match.